### PR TITLE
Add profile endpoint for authenticated users

### DIFF
--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -201,4 +201,31 @@ router.post('/login', authLimiter, loginValidation, async (req, res) => {
   }
 });
 
+// Profile endpoint
+router.get('/profile', authenticateToken, async (req, res) => {
+  try {
+    const user = await userQueries.findById(req.userId);
+    if (!user) {
+      return res.status(404).json({
+        success: false,
+        message: 'User not found'
+      });
+    }
+    res.json({
+      success: true,
+      user: {
+        id: user.id,
+        email: user.email,
+        name: user.name
+      }
+    });
+  } catch (error) {
+    console.error('Profile fetch error:', error);
+    res.status(500).json({
+      success: false,
+      message: 'Internal server error'
+    });
+  }
+});
+
 export default router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -106,6 +106,7 @@ app.listen(PORT, () => {
   console.log(`🔐 Auth endpoints:`);
   console.log(`   POST /api/auth/register - Register new user`);
   console.log(`   POST /api/auth/login - Login user`);
+  console.log(`   GET /api/auth/profile - Get user profile`);
 });
 
 export default app;


### PR DESCRIPTION
## Summary
- add GET /api/auth/profile endpoint to fetch authenticated user details
- log the profile route on server startup

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ab078e29588329ae15bd608a939d0f