### PR TITLE
Add Q1 analysis utilities and condition controls

### DIFF
--- a/eval/q1/README_Q1.md
+++ b/eval/q1/README_Q1.md
@@ -1,0 +1,43 @@
+# Q1 Latency & Presence Analysis
+
+This folder bundles templates and a helper script to analyse Question 1 of the
+study (latence & fluidité).
+
+## Files
+- `q1_turns_template.csv` – example logging output for each dialogue turn.
+- `q1_ipq_template.csv` – example IPQ scores per participant/condition.
+- `analyze_q1.py` – aggregates data, runs repeated-measures ANOVAs and produces
+  plots.
+
+## Usage
+1. Collect your own `turns.csv` and `ipq.csv` following the column structure of
+the templates.
+2. Run the analysis:
+
+```bash
+python analyze_q1.py --turns turns.csv --ipq ipq.csv --out results
+```
+
+The script writes ANOVA tables (`anova_*.csv`), a correlation matrix
+(`correlations.csv`), and plots (`tfft_boxplot.png`, `ipq_presence_bar.png`,
+`ipq_involvement_bar.png`) inside the chosen output directory.
+
+## Required columns
+
+`turns.csv`:
+- `participant_id`
+- `prompt_length` (short|long)
+- `prompt_structure` (spikes|libre)
+- `emotion` (on|off)
+- `t_req_tx_ms`
+- `t_audio_play_start_ms`
+- `tfft_ms` (optional; computed if absent)
+
+`ipq.csv`:
+- `participant_id`
+- `prompt_length`
+- `prompt_structure`
+- `emotion`
+- `ipq_presence`
+- `ipq_involvement`
+

--- a/eval/q1/analyze_q1.py
+++ b/eval/q1/analyze_q1.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Analyze latency (TFFT) and IPQ data for Q1.
+
+The script expects two CSV files:
+- turns.csv: one row per turn with timing information
+- ipq.csv: one row per participant/condition with IPQ scores
+
+It aggregates data per participant and condition, runs 2x2x2 repeated-
+measures ANOVAs on TFFT and IPQ scores, computes Pearson correlations, and
+emits basic plots.
+"""
+import argparse
+import os
+import pandas as pd
+import seaborn as sns
+import matplotlib.pyplot as plt
+from statsmodels.stats.anova import AnovaRM
+
+
+def load_turns(path: str) -> pd.DataFrame:
+    turns = pd.read_csv(path)
+    # derive TFFT if not explicitly provided
+    if 'tfft_ms' not in turns.columns:
+        turns['tfft_ms'] = turns['t_audio_play_start_ms'] - turns['t_req_tx_ms']
+    return turns
+
+
+def aggregate(turns: pd.DataFrame, ipq: pd.DataFrame) -> pd.DataFrame:
+    tfft = (
+        turns.groupby(['participant_id', 'prompt_length', 'prompt_structure', 'emotion'])
+        ['tfft_ms']
+        .mean()
+        .reset_index()
+    )
+    df = pd.merge(
+        tfft,
+        ipq,
+        on=['participant_id', 'prompt_length', 'prompt_structure', 'emotion'],
+        how='inner',
+    )
+    df['condition_id'] = (
+        df['prompt_length'] + '_' + df['prompt_structure'] + '_' + df['emotion']
+    )
+    return df
+
+
+def run_anova(df: pd.DataFrame, dv: str, out_path: str):
+    aov = AnovaRM(
+        df,
+        depvar=dv,
+        subject='participant_id',
+        within=['prompt_length', 'prompt_structure', 'emotion'],
+    ).fit()
+    aov.anova_table.to_csv(out_path)
+    return aov
+
+
+def make_plots(df: pd.DataFrame, out_dir: str):
+    sns.set_theme(style='whitegrid')
+
+    plt.figure()
+    sns.boxplot(data=df, x='condition_id', y='tfft_ms')
+    plt.ylabel('TFFT (ms)')
+    plt.title('TFFT by condition')
+    plt.tight_layout()
+    plt.savefig(os.path.join(out_dir, 'tfft_boxplot.png'))
+
+    plt.figure()
+    sns.barplot(data=df, x='condition_id', y='ipq_presence', ci=None)
+    plt.ylabel('IPQ Presence')
+    plt.title('IPQ Presence by condition')
+    plt.tight_layout()
+    plt.savefig(os.path.join(out_dir, 'ipq_presence_bar.png'))
+
+    plt.figure()
+    sns.barplot(data=df, x='condition_id', y='ipq_involvement', ci=None)
+    plt.ylabel('IPQ Involvement')
+    plt.title('IPQ Involvement by condition')
+    plt.tight_layout()
+    plt.savefig(os.path.join(out_dir, 'ipq_involvement_bar.png'))
+
+
+def main():
+    ap = argparse.ArgumentParser(description='Q1 latency & IPQ analysis')
+    ap.add_argument('--turns', required=True, help='CSV with turn timings')
+    ap.add_argument('--ipq', required=True, help='CSV with IPQ scores')
+    ap.add_argument('--out', required=True, help='directory for outputs')
+    args = ap.parse_args()
+
+    os.makedirs(args.out, exist_ok=True)
+
+    turns = load_turns(args.turns)
+    ipq = pd.read_csv(args.ipq)
+    df = aggregate(turns, ipq)
+
+    # run ANOVAs
+    run_anova(df, 'tfft_ms', os.path.join(args.out, 'anova_tfft.csv'))
+    run_anova(df, 'ipq_presence', os.path.join(args.out, 'anova_ipq_presence.csv'))
+    run_anova(df, 'ipq_involvement', os.path.join(args.out, 'anova_ipq_involvement.csv'))
+
+    # correlations
+    corr = df[['tfft_ms', 'ipq_presence', 'ipq_involvement']].corr(method='pearson')
+    corr.to_csv(os.path.join(args.out, 'correlations.csv'))
+
+    # plots
+    make_plots(df, args.out)
+
+    print(f'Saved results to {args.out}')
+
+
+if __name__ == '__main__':
+    main()

--- a/eval/q1/q1_ipq_template.csv
+++ b/eval/q1/q1_ipq_template.csv
@@ -1,0 +1,3 @@
+participant_id,prompt_length,prompt_structure,emotion,ipq_presence,ipq_involvement
+P01,short,spikes,on,4.5,4.3
+P01,long,libre,off,3.8,3.7

--- a/eval/q1/q1_turns_template.csv
+++ b/eval/q1/q1_turns_template.csv
@@ -1,0 +1,4 @@
+participant_id,condition_id,prompt_length,prompt_structure,emotion,t_req_tx_ms,t_audio_play_start_ms,tfft_ms
+P01,short_spikes_on,short,spikes,on,0,520,520
+P01,short_spikes_on,short,spikes,on,1100,1620,520
+P01,long_libre_off,long,libre,off,0,780,780

--- a/frontend/src/components/UI.jsx
+++ b/frontend/src/components/UI.jsx
@@ -8,7 +8,7 @@ export const UI = ({ hidden, ...props }) => {
     const { user, logout, token } = useAuth();
 
     const input = useRef();
-    const { chat, loading, cameraZoomed, setCameraZoomed, message } = useChat();
+    const { chat, loading, cameraZoomed, setCameraZoomed, message, condition, setCondition } = useChat();
     const [listening, setListening] = useState(false);
     const recognitionRef = useRef(null);
 
@@ -127,8 +127,44 @@ export const UI = ({ hidden, ...props }) => {
                 <span className="text-lg font-semibold text-chaptal-purple">Fondation Léonie Chaptal</span>
             </div>
 
-            {/* Auxiliary buttons */}
+            {/* Auxiliary buttons + Q1 condition controls */}
             <div className="w-full flex flex-col items-end justify-center gap-4 pointer-events-auto">
+                <div className="bg-white bg-opacity-50 backdrop-blur-md p-4 rounded-md flex flex-col gap-2 text-xs">
+                    <label className="flex items-center gap-2">
+                        <span>Longueur</span>
+                        <select
+                            value={condition.promptLength}
+                            onChange={(e) => setCondition({ ...condition, promptLength: e.target.value })}
+                            className="border rounded p-1"
+                        >
+                            <option value="short">Court</option>
+                            <option value="long">Long</option>
+                        </select>
+                    </label>
+                    <label className="flex items-center gap-2">
+                        <span>Structure</span>
+                        <select
+                            value={condition.promptStructure}
+                            onChange={(e) => setCondition({ ...condition, promptStructure: e.target.value })}
+                            className="border rounded p-1"
+                        >
+                            <option value="spikes">SPIKES</option>
+                            <option value="libre">Libre</option>
+                        </select>
+                    </label>
+                    <label className="flex items-center gap-2">
+                        <span>Émotion</span>
+                        <select
+                            value={condition.emotion}
+                            onChange={(e) => setCondition({ ...condition, emotion: e.target.value })}
+                            className="border rounded p-1"
+                        >
+                            <option value="on">On</option>
+                            <option value="off">Off</option>
+                        </select>
+                    </label>
+                </div>
+
                 <button
                     onClick={() => setCameraZoomed(!cameraZoomed)}
                     className="bg-chaptal-green hover:bg-chaptal-green-dark text-white p-4 rounded-md"

--- a/frontend/src/hooks/useChat.jsx
+++ b/frontend/src/hooks/useChat.jsx
@@ -6,6 +6,12 @@ import { measureTFFT } from "../metrics/latency.ts";
 const ChatContext = createContext();
 
 export const ChatProvider = ({ children }) => {
+  const [condition, setCondition] = useState({
+    promptLength: "short",
+    promptStructure: "spikes",
+    emotion: "on",
+  });
+
   const chat = async (message) => {
     setLoading(true);
     let tfft = null;
@@ -15,7 +21,12 @@ export const ChatProvider = ({ children }) => {
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ message }),
+        body: JSON.stringify({
+          message,
+          prompt_length: condition.promptLength,
+          prompt_structure: condition.promptStructure,
+          emotion: condition.emotion,
+        }),
       });
 
       tfft = tfftMs;
@@ -54,6 +65,8 @@ export const ChatProvider = ({ children }) => {
         loading,
         cameraZoomed,
         setCameraZoomed,
+        condition,
+        setCondition,
       }}
     >
       {children}


### PR DESCRIPTION
## Summary
- add `eval/q1/analyze_q1.py`, CSV templates, and `README_Q1.md` for latency analysis
- expose Q1 prompt length/structure/emotion selectors in UI and send condition data with chat requests

## Testing
- `python -m py_compile eval/q1/analyze_q1.py`
- `npm --prefix frontend run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b81d9a892483299f71987e2b8b1e14