### PR TITLE
Validate chat message payload

### DIFF
--- a/backend/routes/tts.js
+++ b/backend/routes/tts.js
@@ -73,18 +73,8 @@ ttsRouter.get("/test-tts", async (req, res) => {
 ttsRouter.post("/chat", tfftMiddleware, async (req, res) => {
     const userMessage = req.body.message;
 
-    if (!userMessage) {
-        return res.send({
-            messages: [
-                {
-                    text: "Coucou mon amour... Comment s'est passée ta journée ?",
-                    audio: await audioFileToBase64("audios/intro_0.wav"),
-                    lipsync: await readJsonTranscript("audios/intro_0.json"),
-                    facialExpression: "smile",
-                    animation: "Talking_1",
-                },
-            ],
-        });
+    if (typeof userMessage !== "string" || userMessage.trim() === "") {
+        return res.status(400).json({ error: "Message is required." });
     }
 
     if (!elevenLabsApiKey || !openai.apiKey) {

--- a/frontend/src/hooks/useChat.jsx
+++ b/frontend/src/hooks/useChat.jsx
@@ -12,7 +12,12 @@ export const ChatProvider = ({ children }) => {
     emotion: "on",
   });
 
-  const chat = async (message) => {
+  const chat = async (prompt) => {
+    if (!prompt || prompt.trim() === "") {
+      console.warn("Chat called without a message");
+      return null;
+    }
+
     setLoading(true);
     let tfft = null;
     try {
@@ -22,7 +27,7 @@ export const ChatProvider = ({ children }) => {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          message,
+          message: prompt,
           prompt_length: condition.promptLength,
           prompt_structure: condition.promptStructure,
           emotion: condition.emotion,


### PR DESCRIPTION
## Summary
- Require a non-empty `message` in `/api/tts/chat` requests and return `400` when absent
- Guard chat hook against empty prompts and ensure message is sent in request body

## Testing
- `npm test` *(fails: Missing script: "test")*
- `cd backend && npm test` *(fails: Missing script: "test")*
- `cd frontend && npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c1923c71648329a6decd1cd1d20902