### PR TITLE
Add timing metrics for OpenAI, ElevenLabs, and avatar processing

### DIFF
--- a/backend/routes/tts.js
+++ b/backend/routes/tts.js
@@ -100,7 +100,8 @@ ttsRouter.post("/chat", async (req, res) => {
         });
     }
 
-    // Generate response with OpenAI
+    // Generate response with OpenAI and measure timing
+    const openAiStart = Date.now();
     const completion = await openai.chat.completions.create({
         model: "gpt-4.1",
         max_tokens: 1000,
@@ -118,22 +119,47 @@ ttsRouter.post("/chat", async (req, res) => {
             { role: "user", content: userMessage },
         ],
     });
+    const openAiMs = Date.now() - openAiStart;
 
     let messages = JSON.parse(completion.choices[0].message.content);
     if (messages.messages) messages = messages.messages;
+
+    let elevenLabsMs = 0;
+    let lipSyncMs = 0;
+    let audioEncodeMs = 0;
+    let transcriptMs = 0;
 
     for (let i = 0; i < messages.length; i++) {
         const msg = messages[i];
         const fileName = `audios/message_${i}.mp3`;
 
+        const ttsStart = Date.now();
         await voice.textToSpeech(elevenLabsApiKey, voiceID, fileName, msg.text);
-        await lipSyncMessage(i);
+        elevenLabsMs += Date.now() - ttsStart;
 
+        const lipStart = Date.now();
+        await lipSyncMessage(i);
+        lipSyncMs += Date.now() - lipStart;
+
+        const audioStart = Date.now();
         msg.audio = await audioFileToBase64(fileName);
+        audioEncodeMs += Date.now() - audioStart;
+
+        const transcriptStart = Date.now();
         msg.lipsync = await readJsonTranscript(`audios/message_${i}.json`);
+        transcriptMs += Date.now() - transcriptStart;
     }
 
-    res.send({ messages });
+    res.send({
+        messages,
+        timings: {
+            openAiMs,
+            elevenLabsMs,
+            lipSyncMs,
+            audioEncodeMs,
+            transcriptMs,
+        },
+    });
 });
 
 export default ttsRouter;

--- a/frontend/src/hooks/useChat.jsx
+++ b/frontend/src/hooks/useChat.jsx
@@ -18,8 +18,13 @@ export const ChatProvider = ({ children }) => {
 
       if (!data.ok) throw new Error(`Request failed with ${data.status}`);
 
-      const resp = (await data.json()).messages || [];
+      const json = await data.json();
+      const resp = json.messages || [];
       setMessages((messages) => [...messages, ...resp]);
+      if (json.timings) {
+        setTimings(json.timings);
+        console.log("⏱️ API timings:", json.timings);
+      }
     } catch (err) {
       console.error("Chat error:", err);
     } finally {
@@ -30,6 +35,7 @@ export const ChatProvider = ({ children }) => {
   const [message, setMessage] = useState();
   const [loading, setLoading] = useState(false);
   const [cameraZoomed, setCameraZoomed] = useState(true);
+  const [timings, setTimings] = useState(null);
   const onMessagePlayed = () => {
     setMessages((messages) => messages.slice(1));
   };
@@ -51,6 +57,7 @@ export const ChatProvider = ({ children }) => {
         loading,
         cameraZoomed,
         setCameraZoomed,
+        timings,
       }}
     >
       {children}

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,11 +1,13 @@
 import { useEffect, useState } from "react";
 import { useAuth } from "../context/AuthContext";
+import { useChat } from "../hooks/useChat";
 import { Loader2 } from "lucide-react";
 import { API_URL } from "../config";
 import "../style.css";
 
 export default function AdminDashboard() {
     const { user, token } = useAuth();
+    const { timings } = useChat();
     const [simulations, setSimulations] = useState([]);
     const [chats, setChats] = useState([]);
     const [loading, setLoading] = useState(true);
@@ -63,6 +65,23 @@ export default function AdminDashboard() {
             <h1 className="text-3xl font-bold text-gray-800 mb-6">
                 Admin Dashboard
             </h1>
+
+            <div className="mb-10 bg-white rounded-2xl shadow-lg p-4">
+                <h2 className="text-xl font-semibold mb-2">
+                    Latest API Timings (ms)
+                </h2>
+                {timings ? (
+                    <ul className="list-disc list-inside text-gray-700">
+                        <li>OpenAI: {timings.openAiMs}</li>
+                        <li>ElevenLabs: {timings.elevenLabsMs}</li>
+                        <li>Lip Sync: {timings.lipSyncMs}</li>
+                        <li>Audio Encoding: {timings.audioEncodeMs}</li>
+                        <li>Transcript: {timings.transcriptMs}</li>
+                    </ul>
+                ) : (
+                    <p className="text-gray-500">No timing data yet.</p>
+                )}
+            </div>
 
             <div className="overflow-x-auto bg-white rounded-2xl shadow-lg mb-10">
                 <h2 className="text-xl font-semibold px-4 py-3 border-b">


### PR DESCRIPTION
## Summary
- measure OpenAI completion, ElevenLabs TTS, and avatar processing steps in TTS route
- log returned timing metrics from the chat hook for debugging
- expose latest API timing metrics on the admin dashboard

## Testing
- `npm test` (backend) *(fails: Missing script: "test")*
- `npm test` (frontend) *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c7ead35ef08329b3dcbb772bab7e4e