### PR TITLE
Add timing metrics for OpenAI, ElevenLabs, and avatar processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 backend/.env
 backend/node_modules
 frontend/node_modules
+node_modules

--- a/backend/routes/chat.js
+++ b/backend/routes/chat.js
@@ -100,7 +100,18 @@ router.post('/api/auth/best_prompt', async (req, res) => {
 
 router.post('/api/auth/simulation', async (req, res) => {
     try {
-        const { userId, prompt, timeSpentSeconds, tfftMs, ipqScore } = req.body;
+        const {
+            userId,
+            prompt,
+            timeSpentSeconds,
+            tfftMs,
+            ipqScore,
+            openAiMs,
+            elevenLabsMs,
+            lipSyncMs,
+            audioEncodeMs,
+            transcriptMs,
+        } = req.body;
 
         if (!prompt || prompt.trim().length === 0) {
             return res.status(400).json({ error: 'Prompt is required' });
@@ -117,14 +128,38 @@ router.post('/api/auth/simulation', async (req, res) => {
         }
 
         await pool.query(
-            `INSERT INTO simulation_sessions (user_id, prompt, prompt_length, time_spent_seconds, tfft_ms, ipq_score)
-             VALUES ($1, $2, $3, $4, $5, $6)`,
-            [userId, prompt, promptLength, timeSpentSeconds, tfftMs ?? null, ipqScore ?? null]
+            `INSERT INTO simulation_sessions (user_id, prompt, prompt_length, time_spent_seconds, tfft_ms, ipq_score, openai_ms, elevenlabs_ms, lip_sync_ms, audio_encode_ms, transcript_ms)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+            [
+                userId,
+                prompt,
+                promptLength,
+                timeSpentSeconds,
+                tfftMs ?? null,
+                ipqScore ?? null,
+                openAiMs ?? null,
+                elevenLabsMs ?? null,
+                lipSyncMs ?? null,
+                audioEncodeMs ?? null,
+                transcriptMs ?? null,
+            ]
         );
 
         res.json({
             success: true,
-            data: { userId, prompt, promptLength, timeSpentSeconds, tfftMs, ipqScore }
+            data: {
+                userId,
+                prompt,
+                promptLength,
+                timeSpentSeconds,
+                tfftMs,
+                ipqScore,
+                openAiMs,
+                elevenLabsMs,
+                lipSyncMs,
+                audioEncodeMs,
+                transcriptMs,
+            },
         });
 
     } catch (error) {
@@ -138,7 +173,8 @@ router.post('/api/auth/simulation', async (req, res) => {
 router.get('/api/simulations', async (req, res) => {
     try {
         const query = `
-            SELECT s.id, u.name, u.email, s.prompt, s.prompt_length, s.time_spent_seconds, s.tfft_ms, s.ipq_score, s.created_at
+            SELECT s.id, u.name, u.email, s.prompt, s.prompt_length, s.time_spent_seconds, s.tfft_ms, s.ipq_score,
+                   s.openai_ms, s.elevenlabs_ms, s.lip_sync_ms, s.audio_encode_ms, s.transcript_ms, s.created_at
             FROM simulation_sessions s
             JOIN users u ON u.id = s.user_id
             ORDER BY s.created_at DESC

--- a/backend/routes/tts.js
+++ b/backend/routes/tts.js
@@ -100,7 +100,8 @@ ttsRouter.post("/chat", async (req, res) => {
         });
     }
 
-    // Generate response with OpenAI
+    // Generate response with OpenAI and measure timing
+    const openAiStart = Date.now();
     const completion = await openai.chat.completions.create({
         model: "gpt-4.1",
         max_tokens: 1000,
@@ -118,22 +119,47 @@ ttsRouter.post("/chat", async (req, res) => {
             { role: "user", content: userMessage },
         ],
     });
+    const openAiMs = Date.now() - openAiStart;
 
     let messages = JSON.parse(completion.choices[0].message.content);
     if (messages.messages) messages = messages.messages;
+
+    let elevenLabsMs = 0;
+    let lipSyncMs = 0;
+    let audioEncodeMs = 0;
+    let transcriptMs = 0;
 
     for (let i = 0; i < messages.length; i++) {
         const msg = messages[i];
         const fileName = `audios/message_${i}.mp3`;
 
+        const ttsStart = Date.now();
         await voice.textToSpeech(elevenLabsApiKey, voiceID, fileName, msg.text);
-        await lipSyncMessage(i);
+        elevenLabsMs += Date.now() - ttsStart;
 
+        const lipStart = Date.now();
+        await lipSyncMessage(i);
+        lipSyncMs += Date.now() - lipStart;
+
+        const audioStart = Date.now();
         msg.audio = await audioFileToBase64(fileName);
+        audioEncodeMs += Date.now() - audioStart;
+
+        const transcriptStart = Date.now();
         msg.lipsync = await readJsonTranscript(`audios/message_${i}.json`);
+        transcriptMs += Date.now() - transcriptStart;
     }
 
-    res.send({ messages });
+    res.send({
+        messages,
+        timings: {
+            openAiMs,
+            elevenLabsMs,
+            lipSyncMs,
+            audioEncodeMs,
+            transcriptMs,
+        },
+    });
 });
 
 export default ttsRouter;

--- a/backend/schema/user_statistics.sql
+++ b/backend/schema/user_statistics.sql
@@ -18,5 +18,10 @@ CREATE TABLE simulation_sessions (
     time_spent_seconds INT,
     tfft_ms INT,
     ipq_score NUMERIC(5,2),
+    openai_ms INT,
+    elevenlabs_ms INT,
+    lip_sync_ms INT,
+    audio_encode_ms INT,
+    transcript_ms INT,
     created_at TIMESTAMP DEFAULT NOW()
 );

--- a/frontend/src/components/UI.jsx
+++ b/frontend/src/components/UI.jsx
@@ -7,7 +7,7 @@ export const UI = ({ hidden, ...props }) => {
     const { user, logout, token } = useAuth();
 
     const input = useRef();
-    const { chat, loading, cameraZoomed, setCameraZoomed, message } = useChat();
+    const { chat, loading, cameraZoomed, setCameraZoomed, message, timings } = useChat();
     const [listening, setListening] = useState(false);
     const recognitionRef = useRef(null);
 
@@ -27,9 +27,9 @@ export const UI = ({ hidden, ...props }) => {
         return () => {
             const endTime = Date.now();
             const timeSpent = Math.floor((endTime - startTime) / 1000);
-            if (lastPromptRef.current) saveSimulation(lastPromptRef.current, timeSpent);
+            if (lastPromptRef.current) saveSimulation(lastPromptRef.current, timeSpent, timings);
         };
-    }, [startTime]);
+    }, [startTime, timings]);
 
     const stopListening = () => {
         if (recognitionRef.current) recognitionRef.current.stop();
@@ -49,13 +49,13 @@ export const UI = ({ hidden, ...props }) => {
         recog.maxAlternatives = 1;
         recog.lang = "fr-FR";
 
-        recog.onresult = (e) => {
+        recog.onresult = async (e) => {
             const transcript = e.results[e.results.length - 1][0].transcript.trim();
             console.log("🎙️ Transcript:", transcript);
 
             stopListening();
-            chat(transcript);
-            saveSimulation(transcript);
+            const metrics = await chat(transcript);
+            saveSimulation(transcript, undefined, metrics);
         };
 
         recog.onend = () => setListening(false);
@@ -66,13 +66,14 @@ export const UI = ({ hidden, ...props }) => {
         recog.start();
     };
 
-    const saveSimulation = (promptText, forcedTimeSpent) => {
+    const saveSimulation = (promptText, forcedTimeSpent, metrics) => {
         lastPromptRef.current = promptText;
 
         const endTime = Date.now();
         const timeSpent = forcedTimeSpent ?? Math.floor((endTime - startTime) / 1000);
 
-        console.log("🚀 Sending simulation:", { promptText, timeSpent });
+        const ipqScore = localStorage.getItem("ipqScore");
+        console.log("🚀 Sending simulation:", { promptText, timeSpent, metrics, ipqScore });
 
         fetch(`${API_URL}/api/auth/simulation`, {
             method: "POST",
@@ -84,16 +85,23 @@ export const UI = ({ hidden, ...props }) => {
                 userId: user?.id,  // ✅ dynamic userId from context
                 prompt: promptText,
                 timeSpentSeconds: Number(timeSpent),
+                tfftMs: metrics?.openAiMs ?? null,
+                ipqScore: ipqScore ? Number(ipqScore) : null,
+                openAiMs: metrics?.openAiMs ?? null,
+                elevenLabsMs: metrics?.elevenLabsMs ?? null,
+                lipSyncMs: metrics?.lipSyncMs ?? null,
+                audioEncodeMs: metrics?.audioEncodeMs ?? null,
+                transcriptMs: metrics?.transcriptMs ?? null,
             }),
         }).catch((err) => console.error("Simulation save error:", err));
     };
 
 
-    const sendMessage = () => {
+    const sendMessage = async () => {
         const text = input.current.value.trim();
         if (!loading && !message && text) {
-            chat(text);
-            saveSimulation(text);
+            const metrics = await chat(text);
+            saveSimulation(text, undefined, metrics);
             input.current.value = "";
         }
     };

--- a/frontend/src/hooks/useChat.jsx
+++ b/frontend/src/hooks/useChat.jsx
@@ -18,8 +18,14 @@ export const ChatProvider = ({ children }) => {
 
       if (!data.ok) throw new Error(`Request failed with ${data.status}`);
 
-      const resp = (await data.json()).messages || [];
+      const json = await data.json();
+      const resp = json.messages || [];
       setMessages((messages) => [...messages, ...resp]);
+      if (json.timings) {
+        setTimings(json.timings);
+        console.log("⏱️ API timings:", json.timings);
+      }
+      return json.timings;
     } catch (err) {
       console.error("Chat error:", err);
     } finally {
@@ -30,6 +36,7 @@ export const ChatProvider = ({ children }) => {
   const [message, setMessage] = useState();
   const [loading, setLoading] = useState(false);
   const [cameraZoomed, setCameraZoomed] = useState(true);
+  const [timings, setTimings] = useState(null);
   const onMessagePlayed = () => {
     setMessages((messages) => messages.slice(1));
   };
@@ -51,6 +58,7 @@ export const ChatProvider = ({ children }) => {
         loading,
         cameraZoomed,
         setCameraZoomed,
+        timings,
       }}
     >
       {children}

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,11 +1,13 @@
 import { useEffect, useState } from "react";
 import { useAuth } from "../context/AuthContext";
+import { useChat } from "../hooks/useChat";
 import { Loader2 } from "lucide-react";
 import { API_URL } from "../config";
 import "../style.css";
 
 export default function AdminDashboard() {
     const { user, token } = useAuth();
+    const { timings } = useChat();
     const [simulations, setSimulations] = useState([]);
     const [chats, setChats] = useState([]);
     const [loading, setLoading] = useState(true);
@@ -64,6 +66,23 @@ export default function AdminDashboard() {
                 Admin Dashboard
             </h1>
 
+            <div className="mb-10 bg-white rounded-2xl shadow-lg p-4">
+                <h2 className="text-xl font-semibold mb-2">
+                    Latest API Timings (ms)
+                </h2>
+                {timings ? (
+                    <ul className="list-disc list-inside text-gray-700">
+                        <li>OpenAI: {timings.openAiMs}</li>
+                        <li>ElevenLabs: {timings.elevenLabsMs}</li>
+                        <li>Lip Sync: {timings.lipSyncMs}</li>
+                        <li>Audio Encoding: {timings.audioEncodeMs}</li>
+                        <li>Transcript: {timings.transcriptMs}</li>
+                    </ul>
+                ) : (
+                    <p className="text-gray-500">No timing data yet.</p>
+                )}
+            </div>
+
             <div className="overflow-x-auto bg-white rounded-2xl shadow-lg mb-10">
                 <h2 className="text-xl font-semibold px-4 py-3 border-b">
                     Simulation Sessions
@@ -78,6 +97,11 @@ export default function AdminDashboard() {
                             <th className="px-4 py-3">Time Spent (s)</th>
                             <th className="px-4 py-3">TFFT (ms)</th>
                             <th className="px-4 py-3">IPQ Score</th>
+                            <th className="px-4 py-3">OpenAI (ms)</th>
+                            <th className="px-4 py-3">ElevenLabs (ms)</th>
+                            <th className="px-4 py-3">Lip Sync (ms)</th>
+                            <th className="px-4 py-3">Audio Encode (ms)</th>
+                            <th className="px-4 py-3">Transcript (ms)</th>
                             <th className="px-4 py-3">Created</th>
                         </tr>
                     </thead>
@@ -94,6 +118,11 @@ export default function AdminDashboard() {
                                 <td className="px-4 py-3">{s.time_spent_seconds}</td>
                                 <td className="px-4 py-3">{s.tfft_ms ?? 'N/A'}</td>
                                 <td className="px-4 py-3">{s.ipq_score ?? 'N/A'}</td>
+                                <td className="px-4 py-3">{s.openai_ms ?? 'N/A'}</td>
+                                <td className="px-4 py-3">{s.elevenlabs_ms ?? 'N/A'}</td>
+                                <td className="px-4 py-3">{s.lip_sync_ms ?? 'N/A'}</td>
+                                <td className="px-4 py-3">{s.audio_encode_ms ?? 'N/A'}</td>
+                                <td className="px-4 py-3">{s.transcript_ms ?? 'N/A'}</td>
                                 <td className="px-4 py-3">
                                     {new Date(s.created_at).toLocaleString()}
                                 </td>


### PR DESCRIPTION
## Summary
- persist OpenAI, ElevenLabs, lip-sync, audio encoding, and transcript timings with each simulation
- return API timings from chat hook so UI can save them alongside TFFT and IPQ score
- display per-simulation API timings on the admin dashboard

## Testing
- `npm test` *(fails: Missing script: "test")*
- `cd backend && npm test` *(fails: Missing script: "test")*
- `cd frontend && npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c7ead35ef08329b3dcbb772bab7e4e