### PR TITLE
Log and forward timing metrics with simulation saves

### DIFF
--- a/frontend/src/components/UI.jsx
+++ b/frontend/src/components/UI.jsx
@@ -1,13 +1,12 @@
 import { useState, useRef, useEffect } from "react";
 import { useChat } from "../hooks/useChat";
 import { useAuth } from "../context/AuthContext";
-import { API_URL } from "../config";
 
 export const UI = ({ hidden, ...props }) => {
     const { user, logout, token } = useAuth();
 
     const input = useRef();
-    const { chat, loading, cameraZoomed, setCameraZoomed, message, timings } = useChat();
+    const { chat, loading, cameraZoomed, setCameraZoomed, message, timings, saveSimulation } = useChat();
     const [listening, setListening] = useState(false);
     const recognitionRef = useRef(null);
 
@@ -32,7 +31,7 @@ export const UI = ({ hidden, ...props }) => {
             const endTime = Date.now();
             const timeSpent = Math.floor((endTime - startTime) / 1000);
             if (lastPromptRef.current)
-                saveSimulation(lastPromptRef.current, timeSpent, latestTimingsRef.current);
+                recordSimulation(lastPromptRef.current, timeSpent, latestTimingsRef.current);
         };
     }, [startTime]);
 
@@ -60,7 +59,7 @@ export const UI = ({ hidden, ...props }) => {
 
             stopListening();
             const t = await chat(transcript);
-            saveSimulation(transcript, undefined, t);
+            recordSimulation(transcript, undefined, t);
         };
 
         recog.onend = () => setListening(false);
@@ -71,29 +70,11 @@ export const UI = ({ hidden, ...props }) => {
         recog.start();
     };
 
-    const saveSimulation = (promptText, forcedTimeSpent, timingData) => {
+    const recordSimulation = (promptText, forcedTimeSpent, timingData) => {
         lastPromptRef.current = promptText;
-
         const endTime = Date.now();
         const timeSpent = forcedTimeSpent ?? Math.floor((endTime - startTime) / 1000);
-        const ipqScore = localStorage.getItem("ipqScore");
-
-        console.log("🚀 Sending simulation:", { promptText, timeSpent, timingData, ipqScore });
-
-        fetch(`${API_URL}/api/auth/simulation`, {
-            method: "POST",
-            headers: {
-                "Content-Type": "application/json",
-                "Authorization": `Bearer ${token}`
-            },
-            body: JSON.stringify({
-                userId: user?.id,  // ✅ dynamic userId from context
-                prompt: promptText,
-                timeSpentSeconds: Number(timeSpent),
-                timings: timingData,
-                ipqScore: ipqScore ? Number(ipqScore) : null,
-            }),
-        }).catch((err) => console.error("Simulation save error:", err));
+        saveSimulation(promptText, timeSpent, timingData, token, user?.id);
     };
 
 
@@ -101,7 +82,7 @@ export const UI = ({ hidden, ...props }) => {
         const text = input.current.value.trim();
         if (!loading && !message && text) {
             const t = await chat(text);
-            saveSimulation(text, undefined, t);
+            recordSimulation(text, undefined, t);
             input.current.value = "";
         }
     };

--- a/frontend/src/hooks/useChat.jsx
+++ b/frontend/src/hooks/useChat.jsx
@@ -31,6 +31,39 @@ export const ChatProvider = ({ children }) => {
       setLoading(false);
     }
   };
+  const saveSimulation = async (
+    prompt,
+    timeSpentSeconds,
+    timingData,
+    token,
+    userId
+  ) => {
+    const ipqScore = localStorage.getItem("ipqScore");
+    console.log("🚀 Sending simulation:", {
+      prompt,
+      timeSpentSeconds,
+      timingData,
+      ipqScore,
+    });
+    try {
+      await fetch(`${API_URL}/api/auth/simulation`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify({
+          userId,
+          prompt,
+          timeSpentSeconds: Number(timeSpentSeconds),
+          timings: timingData,
+          ipqScore: ipqScore ? Number(ipqScore) : null,
+        }),
+      });
+    } catch (err) {
+      console.error("Simulation save error:", err);
+    }
+  };
   const [messages, setMessages] = useState([]);
   const [message, setMessage] = useState();
   const [loading, setLoading] = useState(false);
@@ -57,6 +90,7 @@ export const ChatProvider = ({ children }) => {
         cameraZoomed,
         setCameraZoomed,
         timings,
+        saveSimulation,
       }}
     >
       {children}

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -82,6 +82,7 @@ export default function AdminDashboard() {
                             <th className="px-4 py-3">Audio Encode (ms)</th>
                             <th className="px-4 py-3">Transcript (ms)</th>
                             <th className="px-4 py-3">TFFT (ms)</th>
+                            <th className="px-4 py-3">IPQ Score</th>
                             <th className="px-4 py-3">Created</th>
                         </tr>
                     </thead>
@@ -102,6 +103,7 @@ export default function AdminDashboard() {
                                 <td className="px-4 py-3">{s.audio_encode_ms}</td>
                                 <td className="px-4 py-3">{s.transcript_ms}</td>
                                 <td className="px-4 py-3">{s.tfft_ms}</td>
+                                <td className="px-4 py-3">{s.ipq_score ?? "N/A"}</td>
                                 <td className="px-4 py-3">
                                     {new Date(s.created_at).toLocaleString()}
                                 </td>


### PR DESCRIPTION
## Summary
- Centralize simulation saves in `useChat` with timing metrics and IPQ score
- Forward timing data through UI context when persisting sessions
- Display timing metrics and IPQ score for each simulation on the admin dashboard

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c8199c111c8329a20cd42acd5e514d