### PR TITLE
Add database-backed option for results API

### DIFF
--- a/backend/routes/results.js
+++ b/backend/routes/results.js
@@ -1,0 +1,176 @@
+import express from "express";
+import {
+  aggregateSummary,
+  computeDeltaSeries,
+  getAllSessions,
+  getStudentById,
+  getStudentSessions,
+  getStudentsWithLastActivity,
+  performDeletion,
+} from "../utils/resultsData.js";
+import {
+  fetchSummary as fetchSummaryFromDb,
+  fetchStudents as fetchStudentsFromDb,
+  fetchStudentSeries as fetchStudentSeriesFromDb,
+} from "../services/resultsDb.js";
+
+const router = express.Router();
+
+// Feature flag toggles between mock in-memory data and the PostgreSQL-backed
+// implementation. When RESULTS_USE_DB is "true" we serve live analytics from
+// the database; otherwise we fall back to the deterministic mock helpers.
+const USE_DB = process.env.RESULTS_USE_DB === "true";
+
+const parseRangeParams = (req) => {
+  const { from, to } = req.query;
+  return { from, to };
+};
+
+router.get("/metrics/summary", async (req, res) => {
+  try {
+    const { from, to } = parseRangeParams(req);
+    if (USE_DB) {
+      const summary = await fetchSummaryFromDb({ from, to });
+      return res.json({ ...summary, generatedAt: new Date().toISOString() });
+    }
+
+    const summary = aggregateSummary({ from, to });
+
+    const totalTimeHours = summary.totalTimeSec / 3600;
+    const timeDistribution = summary.timeDistribution.map((entry) => ({
+      studentId: entry.studentId,
+      name: entry.name,
+      totalTimeSec: entry.totalTimeSec,
+    }));
+
+    return res.json({
+      totalStudents: summary.totalStudents,
+      totalSessions: summary.totalSessions,
+      avgBrestScore: summary.avgBrestScore,
+      avgDeltaBrestScore: summary.avgDeltaBrestScore,
+      totalTimeHours,
+      topImprovers: summary.topImprovers,
+      busiestDays: summary.busiestDays,
+      timeDistribution,
+      generatedAt: new Date().toISOString(),
+    });
+  } catch (error) {
+    console.error("Error while building metrics summary", error);
+    return res.status(500).json({ message: "Unable to compute summary metrics." });
+  }
+});
+
+router.get("/students", async (req, res) => {
+  try {
+    const rawQuery = (req.query.query || "").toString();
+    if (USE_DB) {
+      const students = await fetchStudentsFromDb({ query: rawQuery });
+      return res.json(students);
+    }
+    const query = rawQuery.toLowerCase();
+    const students = getStudentsWithLastActivity()
+      .filter((student) =>
+        query
+          ? student.name.toLowerCase().includes(query) || student.id.toLowerCase().includes(query)
+          : true
+      )
+      .map((student) => ({
+        id: student.id,
+        name: student.name,
+        lastActivity: student.lastActivity,
+      }));
+
+    return res.json(students);
+  } catch (error) {
+    console.error("Error while listing students", error);
+    return res.status(500).json({ message: "Unable to load students." });
+  }
+});
+
+router.get("/students/:id/series", async (req, res) => {
+  try {
+    const { id } = req.params;
+    if (USE_DB) {
+      const result = await fetchStudentSeriesFromDb(id);
+      if (!result) {
+        return res.status(404).json({ message: "Student not found" });
+      }
+      return res.json(result);
+    }
+    const student = getStudentById(id);
+
+    if (!student) {
+      return res.status(404).json({ message: "Student not found" });
+    }
+
+    const seriesRaw = getStudentSessions(id);
+    const series = computeDeltaSeries(seriesRaw);
+
+    return res.json({
+      student,
+      series,
+      totalSessions: series.length,
+    });
+  } catch (error) {
+    console.error("Error while reading student series", error);
+    return res.status(500).json({ message: "Unable to load student sessions." });
+  }
+});
+
+router.delete("/data", (req, res) => {
+  try {
+    if (USE_DB) {
+      return res.status(400).json({ message: "Deletion not supported in DB mode." });
+    }
+    const { scope, studentId, from, to, dryRun } = req.body || {};
+
+    if (!scope || !["all", "student", "dateRange"].includes(scope)) {
+      return res.status(400).json({ message: "A valid scope is required." });
+    }
+
+    if (scope === "student" && !studentId) {
+      return res.status(400).json({ message: "studentId is required for student scoped deletions." });
+    }
+
+    if (scope === "dateRange" && (!from || !to)) {
+      return res.status(400).json({ message: "from and to dates are required for date range deletions." });
+    }
+
+    const allSessions = getAllSessions();
+    let matched = [];
+
+    if (scope === "all") {
+      matched = allSessions;
+    } else if (scope === "student") {
+      matched = allSessions.filter((session) => session.studentId === studentId);
+    } else {
+      matched = allSessions.filter((session) => {
+        const ts = new Date(session.timestamp);
+        const fromDate = from ? new Date(from) : null;
+        const toDate = to ? new Date(to) : null;
+        if (Number.isNaN(ts.getTime())) return false;
+        if (fromDate && ts < fromDate) return false;
+        if (toDate && ts > toDate) return false;
+        return true;
+      });
+    }
+
+    if (dryRun !== false) {
+      return res.json({
+        matchedCount: matched.length,
+        deletedCount: 0,
+        warnings: matched.length === 0 ? ["No sessions matched the criteria."] : undefined,
+        sample: matched.slice(0, 5),
+      });
+    }
+
+    const result = performDeletion({ scope, studentId, from, to });
+    return res.json(result);
+  } catch (error) {
+    console.error("Error while deleting data", error);
+    return res.status(500).json({ message: "Unable to delete data." });
+  }
+});
+
+export default router;
+

--- a/backend/server.js
+++ b/backend/server.js
@@ -6,6 +6,7 @@ import morgan from 'morgan';
 import dotenv from 'dotenv';
 import authRouter, { authenticateToken } from './routes/auth.js';
 import chatRouter from './routes/chat.js';
+import resultsRouter from './routes/results.js';
 import { testConnection } from './db.js';
 import ttsRouter from './routes/tts.js';
 
@@ -35,6 +36,7 @@ app.get('/', (req, res) => {
 app.use('/api/auth', authRouter);
 app.use('/api/tts', ttsRouter);
 // Mount chat-related routes under /api to avoid intercepting other routes
+app.use('/api', authenticateToken, resultsRouter);
 app.use('/api', authenticateToken, chatRouter);
 // app.use('/api/chat', authenticateToken, chatRouter); // Alternative namespace if desired
 

--- a/backend/services/resultsDb.js
+++ b/backend/services/resultsDb.js
@@ -1,0 +1,303 @@
+import pool from "../db.js";
+
+/**
+ * Parse an incoming date/time filter into an ISO string accepted by PostgreSQL.
+ * Invalid values resolve to null so the SQL filter ignores that bound.
+ *
+ * @param {string | undefined} value
+ * @returns {string | null}
+ */
+const parseDateParam = (value) => {
+  if (!value) return null;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+};
+
+const normalizeStudentId = (value) =>
+  value === null || value === undefined ? "" : value.toString();
+
+/**
+ * Build a chronological series with delta computation for a list of sessions.
+ *
+ * @param {Array<{
+ *   id: string;
+ *   user_id: string;
+ *   user_name: string | null;
+ *   created_at: Date | string;
+ *   ipq_score: number | null;
+ *   time_spent_seconds: number | null;
+ * }>} rows
+ * @returns {{
+ *   series: Array<{
+ *     id: string;
+ *     studentId: string;
+ *     studentName: string;
+ *     timestamp: string;
+ *     BrestScore: number | null;
+ *     timeSpentSec: number;
+ *     deltaBrestScore: number | null;
+ *   }>;
+ * }}
+ */
+const buildSeriesWithDelta = (rows) => {
+  let previousScore = null;
+  let lastStudentId = null;
+
+  const series = rows.map((row) => {
+    const studentId = normalizeStudentId(row.user_id);
+    const studentName = row.user_name || "Unknown Student";
+    if (studentId !== lastStudentId) {
+      previousScore = null;
+      lastStudentId = studentId;
+    }
+    const sessionId = row.id === null || row.id === undefined ? "" : row.id.toString();
+    const timestamp = row.created_at instanceof Date
+      ? row.created_at.toISOString()
+      : new Date(row.created_at).toISOString();
+
+    const hasScore = row.ipq_score !== null && row.ipq_score !== undefined;
+    const BrestScore = hasScore ? Number(row.ipq_score) : null;
+    const timeSpentSec = row.time_spent_seconds === null || row.time_spent_seconds === undefined
+      ? 0
+      : Number(row.time_spent_seconds);
+
+    let deltaBrestScore = null;
+    if (hasScore && !Number.isNaN(BrestScore)) {
+      if (previousScore !== null) {
+        deltaBrestScore = BrestScore - previousScore;
+      }
+      previousScore = BrestScore;
+    }
+
+    return {
+      id: sessionId,
+      studentId,
+      studentName,
+      timestamp,
+      BrestScore: hasScore && !Number.isNaN(BrestScore) ? BrestScore : null,
+      timeSpentSec: Number.isNaN(timeSpentSec) ? 0 : timeSpentSec,
+      deltaBrestScore,
+    };
+  });
+
+  return { series };
+};
+
+/**
+ * Fetch dashboard summary metrics from PostgreSQL.
+ *
+ * @param {{ from?: string; to?: string }} params
+ * @returns {Promise<{
+ *   totalStudents: number;
+ *   totalSessions: number;
+ *   avgBrestScore: number;
+ *   avgDeltaBrestScore: number;
+ *   totalTimeHours: number;
+ *   topImprovers: Array<{ studentId: string; name: string; avgDelta: number }>;
+ *   busiestDays: Array<{ date: string; sessions: number }>;
+ *   timeDistribution: Array<{ studentId: string; name: string; totalTimeSec: number }>;
+ * }>}
+ */
+export const fetchSummary = async ({ from, to } = {}) => {
+  const fromParam = parseDateParam(from);
+  const toParam = parseDateParam(to);
+
+  const { rows } = await pool.query(
+    `SELECT s.id, s.user_id, s.created_at, s.ipq_score, s.time_spent_seconds, u.name AS user_name
+     FROM simulation_sessions s
+     LEFT JOIN users u ON u.id = s.user_id
+     WHERE ($1::timestamptz IS NULL OR s.created_at >= $1)
+       AND ($2::timestamptz IS NULL OR s.created_at <= $2)
+     ORDER BY s.user_id ASC, s.created_at ASC`,
+    [fromParam, toParam]
+  );
+
+  if (rows.length === 0) {
+    return {
+      totalStudents: 0,
+      totalSessions: 0,
+      avgBrestScore: 0,
+      avgDeltaBrestScore: 0,
+      totalTimeHours: 0,
+      topImprovers: [],
+      busiestDays: [],
+      timeDistribution: [],
+    };
+  }
+
+  const uniqueStudents = new Map();
+  let totalTimeSec = 0;
+  let brestScoreSum = 0;
+  let brestScoreCount = 0;
+  let globalDeltaSum = 0;
+  let globalDeltaCount = 0;
+
+  const busiestDaysMap = new Map();
+  const timeDistributionMap = new Map();
+  const deltaByStudent = new Map();
+
+  let currentStudentId = null;
+  let previousScoreByStudent = null;
+
+  rows.forEach((row) => {
+    const studentId = normalizeStudentId(row.user_id);
+    const studentName = row.user_name || "Unknown Student";
+    uniqueStudents.set(studentId, studentName);
+
+    const timestamp = row.created_at instanceof Date ? row.created_at : new Date(row.created_at);
+    if (!Number.isNaN(timestamp.getTime())) {
+      const dayKey = timestamp.toISOString().split("T")[0];
+      busiestDaysMap.set(dayKey, (busiestDaysMap.get(dayKey) || 0) + 1);
+    }
+
+    const rawTime = row.time_spent_seconds;
+    const timeSpent = rawTime === null || rawTime === undefined ? 0 : Number(rawTime);
+    if (!Number.isNaN(timeSpent)) {
+      totalTimeSec += timeSpent;
+      const current = timeDistributionMap.get(studentId) || {
+        studentId,
+        name: studentName,
+        totalTimeSec: 0,
+      };
+      current.totalTimeSec += timeSpent;
+      timeDistributionMap.set(studentId, current);
+    }
+
+    const hasScore = row.ipq_score !== null && row.ipq_score !== undefined;
+    const score = hasScore ? Number(row.ipq_score) : null;
+    if (hasScore && score !== null && !Number.isNaN(score)) {
+      brestScoreSum += score;
+      brestScoreCount += 1;
+    }
+
+    if (currentStudentId !== studentId) {
+      currentStudentId = studentId;
+      previousScoreByStudent = null;
+    }
+
+    if (hasScore && score !== null && !Number.isNaN(score)) {
+      if (previousScoreByStudent !== null) {
+        const delta = score - previousScoreByStudent;
+        globalDeltaSum += delta;
+        globalDeltaCount += 1;
+
+        const aggregate = deltaByStudent.get(studentId) || {
+          studentId,
+          name: studentName,
+          sum: 0,
+          count: 0,
+        };
+        aggregate.sum += delta;
+        aggregate.count += 1;
+        deltaByStudent.set(studentId, aggregate);
+      }
+      previousScoreByStudent = score;
+    }
+  });
+
+  const topImprovers = Array.from(deltaByStudent.values())
+    .filter((entry) => entry.count > 0)
+    .map((entry) => ({
+      studentId: entry.studentId,
+      name: entry.name,
+      avgDelta: entry.sum / entry.count,
+    }))
+    .sort((a, b) => b.avgDelta - a.avgDelta);
+
+  const busiestDays = Array.from(busiestDaysMap.entries())
+    .map(([date, sessions]) => ({ date, sessions }))
+    .sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0));
+
+  const timeDistribution = Array.from(timeDistributionMap.values()).sort(
+    (a, b) => b.totalTimeSec - a.totalTimeSec
+  );
+
+  return {
+    totalStudents: uniqueStudents.size,
+    totalSessions: rows.length,
+    avgBrestScore: brestScoreCount ? brestScoreSum / brestScoreCount : 0,
+    avgDeltaBrestScore: globalDeltaCount ? globalDeltaSum / globalDeltaCount : 0,
+    totalTimeHours: totalTimeSec / 3600,
+    topImprovers,
+    busiestDays,
+    timeDistribution,
+  };
+};
+
+/**
+ * Fetch searchable students with their last activity timestamp.
+ *
+ * @param {{ query?: string }} params
+ * @returns {Promise<Array<{ id: string; name: string; lastActivity: string | null }>>}
+ */
+export const fetchStudents = async ({ query } = {}) => {
+  const search = query ? query.toString().trim() : "";
+  const values = [];
+
+  let sql = `SELECT u.id, u.name, MAX(s.created_at) AS last_activity
+    FROM users u
+    LEFT JOIN simulation_sessions s ON s.user_id = u.id
+    WHERE u.is_active = true`;
+
+  if (search) {
+    values.push(`%${search}%`);
+    sql += ` AND (u.name ILIKE $1 OR u.id::text ILIKE $1)`;
+  }
+
+  sql += " GROUP BY u.id, u.name ORDER BY u.name ASC";
+
+  const { rows } = await pool.query(sql, values);
+
+  return rows.map((row) => ({
+    id: normalizeStudentId(row.id),
+    name: row.name,
+    lastActivity: row.last_activity ? new Date(row.last_activity).toISOString() : null,
+  }));
+};
+
+/**
+ * Fetch a student's session series with delta computation.
+ *
+ * @param {string} studentId
+ * @returns {Promise<{
+ *   student: { id: string; name: string };
+ *   series: Array<{
+ *     id: string;
+ *     studentId: string;
+ *     studentName: string;
+ *     timestamp: string;
+ *     BrestScore: number | null;
+ *     timeSpentSec: number;
+ *     deltaBrestScore: number | null;
+ *   }>;
+ *   totalSessions: number;
+ * } | null>}
+ */
+export const fetchStudentSeries = async (studentId) => {
+  const studentResult = await pool.query(
+    "SELECT id, name FROM users WHERE id = $1 AND is_active = true",
+    [studentId]
+  );
+
+  const student = studentResult.rows[0];
+  if (!student) {
+    return null;
+  }
+
+  const { rows } = await pool.query(
+    `SELECT s.id, s.user_id, s.created_at, s.ipq_score, s.time_spent_seconds, u.name AS user_name
+     FROM simulation_sessions s
+     LEFT JOIN users u ON u.id = s.user_id
+     WHERE s.user_id = $1
+     ORDER BY s.created_at ASC`,
+    [studentId]
+  );
+
+  const { series } = buildSeriesWithDelta(rows);
+
+  return {
+    student: { id: normalizeStudentId(student.id), name: student.name },
+    series,
+    totalSessions: series.length,
+  };
+};

--- a/backend/utils/resultsData.js
+++ b/backend/utils/resultsData.js
@@ -1,0 +1,261 @@
+// utils/resultsData.js
+// -----------------------------------------------------------------------------
+// Lightweight in-memory dataset and helpers powering the Results workspace.
+// The project does not yet persist the metrics that drive the dashboards, so we
+// provide a mock data layer with deterministic sample content. The helpers
+// expose CRUD-like operations that can later be swapped with real database
+// queries without touching the route handlers.
+// -----------------------------------------------------------------------------
+
+const studentsSeed = [
+  { id: "stu-001", name: "Alice Martin" },
+  { id: "stu-002", name: "Brahim Cohen" },
+  { id: "stu-003", name: "Camille Dubois" },
+  { id: "stu-004", name: "Diego Ferreira" },
+  { id: "stu-005", name: "Emma Haddad" },
+  { id: "stu-006", name: "Farah Idrissi" },
+  { id: "stu-007", name: "Gabriel Nguyen" },
+  { id: "stu-008", name: "Helena Rossi" },
+  { id: "stu-009", name: "Ibrahim Khaled" },
+  { id: "stu-010", name: "Jules Laurent" },
+];
+
+const sessionSeed = [
+  { id: "sess-001", studentId: "stu-001", studentName: "Alice Martin", timestamp: "2024-01-05T09:15:00.000Z", BrestScore: 62, timeSpentSec: 1420 },
+  { id: "sess-002", studentId: "stu-001", studentName: "Alice Martin", timestamp: "2024-02-10T13:25:00.000Z", BrestScore: 68, timeSpentSec: 1560 },
+  { id: "sess-003", studentId: "stu-001", studentName: "Alice Martin", timestamp: "2024-03-18T16:10:00.000Z", BrestScore: 74, timeSpentSec: 1890 },
+  { id: "sess-004", studentId: "stu-002", studentName: "Brahim Cohen", timestamp: "2024-01-08T10:05:00.000Z", BrestScore: 55, timeSpentSec: 1250 },
+  { id: "sess-005", studentId: "stu-002", studentName: "Brahim Cohen", timestamp: "2024-02-14T11:45:00.000Z", BrestScore: 60, timeSpentSec: 1380 },
+  { id: "sess-006", studentId: "stu-002", studentName: "Brahim Cohen", timestamp: "2024-03-21T15:30:00.000Z", BrestScore: 66, timeSpentSec: 1620 },
+  { id: "sess-007", studentId: "stu-003", studentName: "Camille Dubois", timestamp: "2024-01-12T09:40:00.000Z", BrestScore: 71, timeSpentSec: 1760 },
+  { id: "sess-008", studentId: "stu-003", studentName: "Camille Dubois", timestamp: "2024-02-16T12:00:00.000Z", BrestScore: 73, timeSpentSec: 1820 },
+  { id: "sess-009", studentId: "stu-003", studentName: "Camille Dubois", timestamp: "2024-03-22T14:20:00.000Z", BrestScore: 77, timeSpentSec: 1980 },
+  { id: "sess-010", studentId: "stu-004", studentName: "Diego Ferreira", timestamp: "2024-01-18T08:55:00.000Z", BrestScore: 58, timeSpentSec: 1100 },
+  { id: "sess-011", studentId: "stu-004", studentName: "Diego Ferreira", timestamp: "2024-02-21T11:10:00.000Z", BrestScore: 64, timeSpentSec: 1400 },
+  { id: "sess-012", studentId: "stu-004", studentName: "Diego Ferreira", timestamp: "2024-03-25T15:05:00.000Z", BrestScore: 69, timeSpentSec: 1700 },
+  { id: "sess-013", studentId: "stu-005", studentName: "Emma Haddad", timestamp: "2024-01-20T09:05:00.000Z", BrestScore: 66, timeSpentSec: 1500 },
+  { id: "sess-014", studentId: "stu-005", studentName: "Emma Haddad", timestamp: "2024-02-25T12:45:00.000Z", BrestScore: 71, timeSpentSec: 1680 },
+  { id: "sess-015", studentId: "stu-005", studentName: "Emma Haddad", timestamp: "2024-03-28T16:30:00.000Z", BrestScore: 76, timeSpentSec: 1920 },
+  { id: "sess-016", studentId: "stu-006", studentName: "Farah Idrissi", timestamp: "2024-01-24T10:20:00.000Z", BrestScore: 63, timeSpentSec: 1360 },
+  { id: "sess-017", studentId: "stu-006", studentName: "Farah Idrissi", timestamp: "2024-02-28T14:55:00.000Z", BrestScore: 67, timeSpentSec: 1490 },
+  { id: "sess-018", studentId: "stu-006", studentName: "Farah Idrissi", timestamp: "2024-04-01T17:40:00.000Z", BrestScore: 72, timeSpentSec: 1710 },
+  { id: "sess-019", studentId: "stu-007", studentName: "Gabriel Nguyen", timestamp: "2024-01-28T09:35:00.000Z", BrestScore: 59, timeSpentSec: 1200 },
+  { id: "sess-020", studentId: "stu-007", studentName: "Gabriel Nguyen", timestamp: "2024-03-03T13:15:00.000Z", BrestScore: 63, timeSpentSec: 1485 },
+  { id: "sess-021", studentId: "stu-007", studentName: "Gabriel Nguyen", timestamp: "2024-04-07T16:50:00.000Z", BrestScore: 68, timeSpentSec: 1660 },
+  { id: "sess-022", studentId: "stu-008", studentName: "Helena Rossi", timestamp: "2024-02-02T08:45:00.000Z", BrestScore: 72, timeSpentSec: 1750 },
+  { id: "sess-023", studentId: "stu-008", studentName: "Helena Rossi", timestamp: "2024-03-08T11:20:00.000Z", BrestScore: 78, timeSpentSec: 1925 },
+  { id: "sess-024", studentId: "stu-008", studentName: "Helena Rossi", timestamp: "2024-04-12T15:55:00.000Z", BrestScore: 83, timeSpentSec: 2100 },
+  { id: "sess-025", studentId: "stu-009", studentName: "Ibrahim Khaled", timestamp: "2024-02-06T09:10:00.000Z", BrestScore: 61, timeSpentSec: 1320 },
+  { id: "sess-026", studentId: "stu-009", studentName: "Ibrahim Khaled", timestamp: "2024-03-12T12:40:00.000Z", BrestScore: 66, timeSpentSec: 1515 },
+  { id: "sess-027", studentId: "stu-009", studentName: "Ibrahim Khaled", timestamp: "2024-04-16T17:05:00.000Z", BrestScore: 70, timeSpentSec: 1740 },
+  { id: "sess-028", studentId: "stu-010", studentName: "Jules Laurent", timestamp: "2024-02-10T10:30:00.000Z", BrestScore: 58, timeSpentSec: 1180 },
+  { id: "sess-029", studentId: "stu-010", studentName: "Jules Laurent", timestamp: "2024-03-15T14:00:00.000Z", BrestScore: 63, timeSpentSec: 1440 },
+  { id: "sess-030", studentId: "stu-010", studentName: "Jules Laurent", timestamp: "2024-04-19T18:35:00.000Z", BrestScore: 69, timeSpentSec: 1695 },
+];
+
+let students = [...studentsSeed];
+let sessions = [...sessionSeed];
+
+const clone = (value) => JSON.parse(JSON.stringify(value));
+
+const parseDate = (value) => {
+  if (!value) return null;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+};
+
+const withinRange = (session, from, to) => {
+  const ts = new Date(session.timestamp);
+  if (Number.isNaN(ts.getTime())) return false;
+  if (from && ts < from) return false;
+  if (to && ts > to) return false;
+  return true;
+};
+
+export const getAllStudents = () => clone(students);
+
+export const getAllSessions = () => clone(sessions);
+
+export const getSessionsFiltered = ({ from, to } = {}) => {
+  const fromDate = parseDate(from);
+  const toDate = parseDate(to);
+  return sessions.filter((session) => withinRange(session, fromDate, toDate));
+};
+
+export const getStudentsWithLastActivity = () => {
+  const lastActivityMap = new Map();
+  sessions.forEach((session) => {
+    const current = lastActivityMap.get(session.studentId);
+    if (!current || new Date(session.timestamp) > new Date(current)) {
+      lastActivityMap.set(session.studentId, session.timestamp);
+    }
+  });
+
+  return students.map((student) => ({
+    ...student,
+    lastActivity: lastActivityMap.get(student.id) || null,
+  }));
+};
+
+export const getStudentById = (id) => clone(students.find((student) => student.id === id) || null);
+
+export const getStudentSessions = (studentId) =>
+  clone(
+    sessions
+      .filter((session) => session.studentId === studentId)
+      .sort((a, b) => new Date(a.timestamp) - new Date(b.timestamp))
+  );
+
+export const upsertStudent = (student) => {
+  const index = students.findIndex((item) => item.id === student.id);
+  if (index >= 0) {
+    students[index] = { ...students[index], ...student };
+  } else {
+    students.push({ ...student });
+  }
+};
+
+export const replaceSessions = (nextSessions) => {
+  sessions = [...nextSessions];
+};
+
+export const deleteSessions = (idsToDelete = []) => {
+  const idSet = new Set(idsToDelete);
+  const before = sessions.length;
+  sessions = sessions.filter((session) => !idSet.has(session.id));
+  return before - sessions.length;
+};
+
+export const resetResultsData = () => {
+  students = [...studentsSeed];
+  sessions = [...sessionSeed];
+};
+
+export const computeDeltaSeries = (series) => {
+  let previousScore = null;
+  return series.map((item) => {
+    const delta =
+      typeof item.deltaBrestScore === "number"
+        ? item.deltaBrestScore
+        : previousScore === null
+        ? null
+        : Number(item.BrestScore) - previousScore;
+    previousScore = Number(item.BrestScore);
+    return { ...item, deltaBrestScore: delta };
+  });
+};
+
+export const aggregateSummary = ({ from, to } = {}) => {
+  const filtered = getSessionsFiltered({ from, to });
+  const uniqueStudents = new Set(filtered.map((session) => session.studentId));
+  const totalSessions = filtered.length;
+  const avgBrestScore =
+    totalSessions === 0
+      ? 0
+      : filtered.reduce((sum, session) => sum + Number(session.BrestScore || 0), 0) / totalSessions;
+
+  const deltaValues = [];
+  const deltaByStudent = new Map();
+  uniqueStudents.forEach((studentId) => {
+    const studentSessions = computeDeltaSeries(
+      filtered
+        .filter((session) => session.studentId === studentId)
+        .sort((a, b) => new Date(a.timestamp) - new Date(b.timestamp))
+    );
+
+    const deltas = studentSessions
+      .map((session) => session.deltaBrestScore)
+      .filter((value) => typeof value === "number");
+
+    deltas.forEach((value) => deltaValues.push(value));
+    if (deltas.length > 0) {
+      const average = deltas.reduce((sum, value) => sum + value, 0) / deltas.length;
+      deltaByStudent.set(studentSessions[0].studentId, {
+        studentId: studentSessions[0].studentId,
+        name: studentSessions[0].studentName,
+        avgDelta: average,
+      });
+    }
+  });
+
+  const avgDeltaBrestScore = deltaValues.length
+    ? deltaValues.reduce((sum, value) => sum + value, 0) / deltaValues.length
+    : 0;
+
+  const totalTimeSec = filtered.reduce((sum, session) => sum + Number(session.timeSpentSec || 0), 0);
+
+  const busiestDaysMap = new Map();
+  filtered.forEach((session) => {
+    const dayKey = new Date(session.timestamp).toISOString().split("T")[0];
+    busiestDaysMap.set(dayKey, (busiestDaysMap.get(dayKey) || 0) + 1);
+  });
+
+  const busiestDays = Array.from(busiestDaysMap.entries())
+    .map(([date, sessionsCount]) => ({ date, sessions: sessionsCount }))
+    .sort((a, b) => new Date(a.date) - new Date(b.date));
+
+  const timeByStudentMap = new Map();
+  filtered.forEach((session) => {
+    const key = session.studentId;
+    const current = timeByStudentMap.get(key) || {
+      studentId: key,
+      name: session.studentName,
+      totalTimeSec: 0,
+    };
+    current.totalTimeSec += Number(session.timeSpentSec || 0);
+    timeByStudentMap.set(key, current);
+  });
+
+  const timeDistribution = Array.from(timeByStudentMap.values()).sort(
+    (a, b) => b.totalTimeSec - a.totalTimeSec
+  );
+
+  const topImprovers = Array.from(deltaByStudent.values()).sort((a, b) => b.avgDelta - a.avgDelta);
+
+  return {
+    totalStudents: uniqueStudents.size,
+    totalSessions,
+    avgBrestScore,
+    avgDeltaBrestScore,
+    totalTimeSec,
+    topImprovers,
+    busiestDays,
+    timeDistribution,
+  };
+};
+
+export const performDeletion = ({ scope, studentId, from, to }) => {
+  const fromDate = parseDate(from);
+  const toDate = parseDate(to);
+
+  let candidates = [];
+  if (scope === "all") {
+    candidates = [...sessions];
+  } else if (scope === "student" && studentId) {
+    candidates = sessions.filter((session) => session.studentId === studentId);
+  } else if (scope === "dateRange") {
+    candidates = sessions.filter((session) => withinRange(session, fromDate, toDate));
+  }
+
+  const matchedCount = candidates.length;
+  const sample = clone(candidates.slice(0, 5));
+
+  if (matchedCount === 0) {
+    return { matchedCount: 0, deletedCount: 0, sample, warnings: ["No sessions matched the criteria."] };
+  }
+
+  const ids = candidates.map((session) => session.id);
+  const deletedCount = deleteSessions(ids);
+
+  const warnings = [];
+  if (scope === "student" && studentId && !sessions.some((session) => session.studentId === studentId)) {
+    warnings.push("Selected student no longer has sessions.");
+  }
+
+  if (scope === "all") {
+    warnings.push("All session metrics have been removed from the mock dataset.");
+  }
+
+  return { matchedCount, deletedCount, sample, warnings };
+};
+

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node --test"
   },
   "dependencies": {
     "@react-three/drei": "^9.122.0",
@@ -15,6 +16,7 @@
     "@types/three": "0.152.1",
     "leva": "^0.9.35",
     "lucide-react": "^0.542.0",
+    "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.30.1",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,10 @@ import Chat from "./pages/Chat";
 import AuthPage from "./pages/Auth";
 import Simulation from "./pages/Simulation";
 import AdminDashboard from "./pages/Dashboard"; // Admin dashboard page
+import ResultsLayout from "./pages/results/ResultsLayout";
+import DashboardPage from "./pages/results/DashboardPage";
+import StudentsPage from "./pages/results/StudentsPage";
+import AdminPage from "./pages/results/AdminPage";
 
 // --- AdminRoute wrapper ---
 function AdminRoute({ children }) {
@@ -73,6 +77,21 @@ export default function App() {
               </ProtectedRoute>
             }
           />
+
+          <Route
+            path="/results"
+            element={
+              <ProtectedRoute>
+                <AdminRoute>
+                  <ResultsLayout />
+                </AdminRoute>
+              </ProtectedRoute>
+            }
+          >
+            <Route index element={<DashboardPage />} />
+            <Route path="students" element={<StudentsPage />} />
+            <Route path="admin" element={<AdminPage />} />
+          </Route>
 
           {/* Catch-all route */}
           <Route

--- a/frontend/src/components/results/ColumnChart.jsx
+++ b/frontend/src/components/results/ColumnChart.jsx
@@ -1,0 +1,38 @@
+import PropTypes from "prop-types";
+
+export default function ColumnChart({ data, width = 600, height = 240, valueKey = "value", labelKey = "label" }) {
+  const padding = 40;
+  const maxValue = Math.max(...data.map((item) => Number(item[valueKey]) || 0), 1);
+  const usableWidth = width - padding * 2;
+  const columnWidth = data.length > 0 ? usableWidth / data.length - 8 : 20;
+
+  return (
+    <svg viewBox={`0 0 ${width} ${height}`} role="img" aria-label="Histogramme">
+      <line x1={padding} y1={height - padding} x2={width - padding} y2={height - padding} stroke="#e2e8f0" />
+      {data.map((item, index) => {
+        const value = Number(item[valueKey]) || 0;
+        const ratio = value / maxValue;
+        const barHeight = ratio * (height - padding * 1.5);
+        const x = padding + index * (usableWidth / Math.max(1, data.length)) + 4;
+        const y = height - padding - barHeight;
+        return (
+          <g key={`${item[labelKey]}-${index}`}>
+            <rect x={x} y={y} width={Math.max(8, columnWidth)} height={barHeight} fill="#0ea5e9" rx={6} />
+            <text x={x + Math.max(8, columnWidth) / 2} y={height - padding + 16} fontSize="10" textAnchor="middle" fill="#475569">
+              {item[labelKey]}
+            </text>
+          </g>
+        );
+      })}
+    </svg>
+  );
+}
+
+ColumnChart.propTypes = {
+  data: PropTypes.arrayOf(PropTypes.object).isRequired,
+  width: PropTypes.number,
+  height: PropTypes.number,
+  valueKey: PropTypes.string,
+  labelKey: PropTypes.string,
+};
+

--- a/frontend/src/components/results/ConfirmDialog.jsx
+++ b/frontend/src/components/results/ConfirmDialog.jsx
@@ -1,0 +1,44 @@
+import PropTypes from "prop-types";
+
+export default function ConfirmDialog({ open, title, description, confirmLabel, onCancel, onConfirm, confirmDisabled }) {
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/50 px-4">
+      <div className="w-full max-w-md rounded-2xl border border-slate-200 bg-white p-6 shadow-xl">
+        <header className="mb-4">
+          <h2 className="text-lg font-semibold text-slate-900">{title}</h2>
+          {description && <p className="mt-2 text-sm text-slate-600">{description}</p>}
+        </header>
+        <footer className="mt-6 flex justify-end gap-3">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded-lg border border-slate-200 px-4 py-2 text-sm font-medium text-slate-600 hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          >
+            Annuler
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={confirmDisabled}
+            className="rounded-lg bg-rose-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-rose-700 focus:outline-none focus:ring-2 focus:ring-rose-400 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {confirmLabel}
+          </button>
+        </footer>
+      </div>
+    </div>
+  );
+}
+
+ConfirmDialog.propTypes = {
+  open: PropTypes.bool,
+  title: PropTypes.string.isRequired,
+  description: PropTypes.string,
+  confirmLabel: PropTypes.string.isRequired,
+  onCancel: PropTypes.func.isRequired,
+  onConfirm: PropTypes.func.isRequired,
+  confirmDisabled: PropTypes.bool,
+};
+

--- a/frontend/src/components/results/DataTable.jsx
+++ b/frontend/src/components/results/DataTable.jsx
@@ -1,0 +1,51 @@
+import PropTypes from "prop-types";
+
+export default function DataTable({ columns, rows, emptyLabel = "Aucune donnée" }) {
+  return (
+    <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+      <table className="min-w-full divide-y divide-slate-200 text-sm">
+        <thead className="bg-slate-50">
+          <tr>
+            {columns.map((column) => (
+              <th key={column.key} className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+                {column.label}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-100">
+          {rows.length === 0 ? (
+            <tr>
+              <td className="px-4 py-6 text-center text-sm text-slate-500" colSpan={columns.length}>
+                {emptyLabel}
+              </td>
+            </tr>
+          ) : (
+            rows.map((row) => (
+              <tr key={row.id} className="hover:bg-indigo-50/40">
+                {columns.map((column) => (
+                  <td key={column.key} className="px-4 py-3 text-slate-700">
+                    {column.render ? column.render(row[column.key], row) : row[column.key]}
+                  </td>
+                ))}
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+DataTable.propTypes = {
+  columns: PropTypes.arrayOf(
+    PropTypes.shape({
+      key: PropTypes.string.isRequired,
+      label: PropTypes.string.isRequired,
+      render: PropTypes.func,
+    })
+  ).isRequired,
+  rows: PropTypes.arrayOf(PropTypes.object).isRequired,
+  emptyLabel: PropTypes.string,
+};
+

--- a/frontend/src/components/results/DeleteForm.jsx
+++ b/frontend/src/components/results/DeleteForm.jsx
@@ -1,0 +1,148 @@
+import { useEffect, useState } from "react";
+import PropTypes from "prop-types";
+import StudentsSearch from "./StudentsSearch";
+
+export default function DeleteForm({
+  scope,
+  onScopeChange,
+  studentQuery,
+  onStudentQueryChange,
+  students,
+  onSelectStudent,
+  selectedStudent,
+  dateRange,
+  onDateRangeChange,
+  isLoadingStudents,
+  studentError,
+}) {
+  const [localFrom, setLocalFrom] = useState(dateRange?.from || "");
+  const [localTo, setLocalTo] = useState(dateRange?.to || "");
+
+  useEffect(() => {
+    if (scope === "dateRange") {
+      onDateRangeChange({ from: localFrom, to: localTo });
+    }
+  }, [scope, localFrom, localTo, onDateRangeChange]);
+
+  useEffect(() => {
+    setLocalFrom(dateRange?.from || "");
+    setLocalTo(dateRange?.to || "");
+  }, [dateRange]);
+
+  return (
+    <form className="space-y-6">
+      <fieldset className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+        <legend className="text-sm font-semibold text-slate-700">Portée de la suppression</legend>
+        <div className="mt-3 space-y-2 text-sm text-slate-700">
+          <label className="flex cursor-pointer items-center gap-3 rounded-xl border border-slate-200 px-3 py-2 hover:border-rose-300">
+            <input
+              type="radio"
+              name="scope"
+              value="all"
+              checked={scope === "all"}
+              onChange={(event) => onScopeChange(event.target.value)}
+              className="text-rose-500 focus:ring-rose-400"
+            />
+            <div>
+              <p className="font-semibold">Toutes les données</p>
+              <p className="text-xs text-slate-500">Supprime l'ensemble des sessions enregistrées.</p>
+            </div>
+          </label>
+          <label className="flex cursor-pointer items-center gap-3 rounded-xl border border-slate-200 px-3 py-2 hover:border-rose-300">
+            <input
+              type="radio"
+              name="scope"
+              value="student"
+              checked={scope === "student"}
+              onChange={(event) => onScopeChange(event.target.value)}
+              className="text-rose-500 focus:ring-rose-400"
+            />
+            <div>
+              <p className="font-semibold">Par étudiant</p>
+              <p className="text-xs text-slate-500">Supprime uniquement les sessions du profil sélectionné.</p>
+            </div>
+          </label>
+          <label className="flex cursor-pointer items-center gap-3 rounded-xl border border-slate-200 px-3 py-2 hover:border-rose-300">
+            <input
+              type="radio"
+              name="scope"
+              value="dateRange"
+              checked={scope === "dateRange"}
+              onChange={(event) => onScopeChange(event.target.value)}
+              className="text-rose-500 focus:ring-rose-400"
+            />
+            <div>
+              <p className="font-semibold">Par période</p>
+              <p className="text-xs text-slate-500">Supprime les sessions dont la date est comprise dans l'intervalle.</p>
+            </div>
+          </label>
+        </div>
+      </fieldset>
+
+      {scope === "student" && (
+        <StudentsSearch
+          query={studentQuery}
+          onQueryChange={onStudentQueryChange}
+          results={students}
+          onSelect={onSelectStudent}
+          selectedId={selectedStudent?.id || null}
+          isLoading={isLoadingStudents}
+          error={studentError}
+        />
+      )}
+
+      {scope === "dateRange" && (
+        <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+          <p className="mb-3 text-sm font-semibold text-slate-700">Sélectionnez la période concernée</p>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <label className="flex flex-col text-xs font-medium text-slate-600">
+              Du
+              <input
+                type="date"
+                value={localFrom}
+                onChange={(event) => setLocalFrom(event.target.value)}
+                className="mt-1 rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-rose-400 focus:outline-none focus:ring-2 focus:ring-rose-200"
+              />
+            </label>
+            <label className="flex flex-col text-xs font-medium text-slate-600">
+              Au
+              <input
+                type="date"
+                value={localTo}
+                onChange={(event) => setLocalTo(event.target.value)}
+                className="mt-1 rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-rose-400 focus:outline-none focus:ring-2 focus:ring-rose-200"
+              />
+            </label>
+          </div>
+        </div>
+      )}
+    </form>
+  );
+}
+
+DeleteForm.propTypes = {
+  scope: PropTypes.oneOf(["all", "student", "dateRange"]).isRequired,
+  onScopeChange: PropTypes.func.isRequired,
+  studentQuery: PropTypes.string.isRequired,
+  onStudentQueryChange: PropTypes.func.isRequired,
+  students: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired,
+      lastActivity: PropTypes.string,
+    })
+  ).isRequired,
+  onSelectStudent: PropTypes.func.isRequired,
+  selectedStudent: PropTypes.shape({
+    id: PropTypes.string,
+    name: PropTypes.string,
+  }),
+  dateRange: PropTypes.shape({
+    from: PropTypes.string,
+    to: PropTypes.string,
+  }),
+  onDateRangeChange: PropTypes.func.isRequired,
+  isLoadingStudents: PropTypes.bool,
+  studentError: PropTypes.string,
+};
+

--- a/frontend/src/components/results/HorizontalBarChart.jsx
+++ b/frontend/src/components/results/HorizontalBarChart.jsx
@@ -1,0 +1,38 @@
+import PropTypes from "prop-types";
+
+export default function HorizontalBarChart({ data, valueKey = "value", labelKey = "label", maxLabelWidth = 160 }) {
+  const maxValue = Math.max(...data.map((item) => Math.abs(Number(item[valueKey]) || 0)), 1);
+
+  return (
+    <div className="space-y-2">
+      {data.map((item) => {
+        const value = Number(item[valueKey]) || 0;
+        const magnitude = Math.abs(value);
+        const percentage = Math.max(2, Math.round((magnitude / maxValue) * 100));
+        return (
+          <div key={item[labelKey]} className="flex items-center gap-3">
+            <div className="w-[140px] text-xs font-medium text-slate-600" style={{ maxWidth: maxLabelWidth }}>
+              {item[labelKey]}
+            </div>
+            <div className="flex-1 rounded-full bg-slate-100">
+              <div
+                className="rounded-full bg-emerald-500 px-3 py-1 text-right text-xs font-semibold text-white"
+                style={{ width: `${percentage}%` }}
+              >
+                {value > 0 ? "+" : ""}{value.toFixed(2)}
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+HorizontalBarChart.propTypes = {
+  data: PropTypes.arrayOf(PropTypes.object).isRequired,
+  valueKey: PropTypes.string,
+  labelKey: PropTypes.string,
+  maxLabelWidth: PropTypes.number,
+};
+

--- a/frontend/src/components/results/KpiCard.jsx
+++ b/frontend/src/components/results/KpiCard.jsx
@@ -1,0 +1,34 @@
+import PropTypes from "prop-types";
+
+const accentClasses = {
+  default: "bg-indigo-50 text-indigo-700 border-indigo-200",
+  success: "bg-emerald-50 text-emerald-700 border-emerald-200",
+  warning: "bg-amber-50 text-amber-700 border-amber-200",
+  danger: "bg-rose-50 text-rose-700 border-rose-200",
+};
+
+export default function KpiCard({ title, value, subtitle, accent = "default", icon }) {
+  const accentClass = accentClasses[accent] || accentClasses.default;
+
+  return (
+    <article className={`rounded-xl border ${accentClass} p-4 shadow-sm transition hover:shadow-md`}>
+      <div className="flex items-center gap-3">
+        {icon && <span className="text-2xl" aria-hidden>{icon}</span>}
+        <div>
+          <p className="text-sm font-medium uppercase tracking-wide text-slate-600">{title}</p>
+          <p className="mt-1 text-2xl font-semibold text-slate-900">{value}</p>
+          {subtitle && <p className="mt-1 text-sm text-slate-600">{subtitle}</p>}
+        </div>
+      </div>
+    </article>
+  );
+}
+
+KpiCard.propTypes = {
+  title: PropTypes.string.isRequired,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  subtitle: PropTypes.string,
+  accent: PropTypes.oneOf(["default", "success", "warning", "danger"]),
+  icon: PropTypes.node,
+};
+

--- a/frontend/src/components/results/LineTrendChart.jsx
+++ b/frontend/src/components/results/LineTrendChart.jsx
@@ -1,0 +1,49 @@
+import PropTypes from "prop-types";
+
+export default function LineTrendChart({ data, width = 600, height = 240, valueKey = "value", labelKey = "label" }) {
+  const padding = 40;
+  const maxValue = Math.max(...data.map((item) => Number(item[valueKey]) || 0), 1);
+  const minValue = Math.min(...data.map((item) => Number(item[valueKey]) || 0), 0);
+  const range = maxValue - minValue || 1;
+  const usableWidth = width - padding * 2;
+  const usableHeight = height - padding * 1.5;
+
+  const points = data.map((item, index) => {
+    const ratio = data.length > 1 ? index / (data.length - 1) : 0.5;
+    const x = padding + ratio * usableWidth;
+    const value = Number(item[valueKey]) || 0;
+    const y = height - padding - ((value - minValue) / range) * usableHeight;
+    return { ...item, x, y, value };
+  });
+
+  const zeroRatio = (0 - minValue) / range;
+  const baselineInRange = zeroRatio >= 0 && zeroRatio <= 1;
+  const baselineY = height - padding - zeroRatio * usableHeight;
+  const path = points.map((point, index) => `${index === 0 ? "M" : "L"} ${point.x} ${point.y}`).join(" ");
+
+  return (
+    <svg viewBox={`0 0 ${width} ${height}`} role="img" aria-label="Tendance">
+      {baselineInRange && (
+        <line x1={padding} y1={baselineY} x2={width - padding} y2={baselineY} stroke="#e2e8f0" strokeDasharray="4 4" />
+      )}
+      <path d={path} fill="none" stroke="#6366f1" strokeWidth="2" />
+      {points.map((point, index) => (
+        <circle key={`${point[labelKey]}-${index}`} cx={point.x} cy={point.y} r={4} fill="#4338ca" />
+      ))}
+      {points.map((point, index) => (
+        <text key={`${point[labelKey]}-label-${index}`} x={point.x} y={height - padding + 16} fontSize="10" textAnchor="middle" fill="#475569">
+          {point[labelKey]}
+        </text>
+      ))}
+    </svg>
+  );
+}
+
+LineTrendChart.propTypes = {
+  data: PropTypes.arrayOf(PropTypes.object).isRequired,
+  width: PropTypes.number,
+  height: PropTypes.number,
+  valueKey: PropTypes.string,
+  labelKey: PropTypes.string,
+};
+

--- a/frontend/src/components/results/SessionsAreaChart.jsx
+++ b/frontend/src/components/results/SessionsAreaChart.jsx
@@ -1,0 +1,72 @@
+import PropTypes from "prop-types";
+
+function buildPath(points, baselineY) {
+  if (points.length === 0) return "";
+  const start = `M ${points[0].x} ${baselineY}`;
+  const lines = points.map((point) => `L ${point.x} ${point.y}`).join(" ");
+  const close = `L ${points[points.length - 1].x} ${baselineY} Z`;
+  return `${start} ${lines} ${close}`;
+}
+
+export default function SessionsAreaChart({ data, width = 620, height = 240 }) {
+  const padding = 40;
+  const usableWidth = width - padding * 2;
+  const usableHeight = height - padding * 1.5;
+  const maxValue = Math.max(...data.map((item) => item.sessions || item.value || 0), 1);
+
+  const points = data.map((item, index) => {
+    const ratio = data.length > 1 ? index / (data.length - 1) : 0.5;
+    const x = padding + ratio * usableWidth;
+    const y = height - padding - ((item.sessions || item.value || 0) / maxValue) * usableHeight;
+    return { ...item, x, y };
+  });
+
+  const baselineY = height - padding;
+  const areaPath = buildPath(points, baselineY);
+
+  return (
+    <svg viewBox={`0 0 ${width} ${height}`} role="img" aria-label="Sessions quotidiennes">
+      <defs>
+        <linearGradient id="areaGradient" x1="0" x2="0" y1="0" y2="1">
+          <stop offset="0%" stopColor="#6366f1" stopOpacity="0.6" />
+          <stop offset="100%" stopColor="#6366f1" stopOpacity="0.05" />
+        </linearGradient>
+      </defs>
+      <line x1={padding} y1={baselineY} x2={width - padding} y2={baselineY} stroke="#cbd5f5" strokeWidth="1" />
+      <line x1={padding} y1={padding / 2} x2={padding} y2={baselineY} stroke="#cbd5f5" strokeWidth="1" />
+      <path d={areaPath} fill="url(#areaGradient)" stroke="#6366f1" strokeWidth="2" />
+      {points.map((point, index) => (
+        <circle key={`${point.label}-${index}`} cx={point.x} cy={point.y} r={4} fill="#4338ca" />
+      ))}
+      {points.map((point, index) => (
+        <text
+          key={`${point.label}-label-${index}`}
+          x={point.x}
+          y={baselineY + 16}
+          fontSize="10"
+          textAnchor="middle"
+          fill="#475569"
+        >
+          {index === 0 || index === points.length - 1
+            ? point.label
+            : index % Math.max(1, Math.round(points.length / 6)) === 0
+            ? point.label
+            : ""}
+        </text>
+      ))}
+    </svg>
+  );
+}
+
+SessionsAreaChart.propTypes = {
+  data: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.string.isRequired,
+      sessions: PropTypes.number,
+      value: PropTypes.number,
+    })
+  ).isRequired,
+  width: PropTypes.number,
+  height: PropTypes.number,
+};
+

--- a/frontend/src/components/results/StudentCharts.jsx
+++ b/frontend/src/components/results/StudentCharts.jsx
@@ -1,0 +1,50 @@
+import PropTypes from "prop-types";
+import { formatDate } from "../../lib/results/utils";
+import LineTrendChart from "./LineTrendChart";
+import ColumnChart from "./ColumnChart";
+
+export default function StudentCharts({ series }) {
+  const chartData = series.map((session) => ({
+    ...session,
+    label: formatDate(session.timestamp),
+  }));
+
+  return (
+    <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+      <section className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+        <header className="mb-4">
+          <h3 className="text-lg font-semibold text-slate-800">Δ BRESTScore</h3>
+          <p className="text-xs text-slate-500">Variation du score session par session</p>
+        </header>
+        <div className="h-72">
+          <LineTrendChart data={chartData.map((item) => ({ ...item, value: item.deltaBrestScore, label: item.label }))} />
+        </div>
+      </section>
+
+      <section className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+        <header className="mb-4">
+          <h3 className="text-lg font-semibold text-slate-800">Temps passé par session</h3>
+          <p className="text-xs text-slate-500">Durée totale en minutes</p>
+        </header>
+        <div className="h-72">
+          <ColumnChart
+            data={chartData.map((item) => ({ ...item, value: item.timeSpentSec, label: item.label }))}
+            valueKey="value"
+          />
+        </div>
+      </section>
+    </div>
+  );
+}
+
+StudentCharts.propTypes = {
+  series: PropTypes.arrayOf(
+    PropTypes.shape({
+      timestamp: PropTypes.string.isRequired,
+      BrestScore: PropTypes.number.isRequired,
+      deltaBrestScore: PropTypes.number,
+      timeSpentSec: PropTypes.number.isRequired,
+    })
+  ).isRequired,
+};
+

--- a/frontend/src/components/results/StudentsSearch.jsx
+++ b/frontend/src/components/results/StudentsSearch.jsx
@@ -1,0 +1,100 @@
+import { useEffect, useRef } from "react";
+import PropTypes from "prop-types";
+import { formatDate } from "../../lib/results/utils";
+
+export default function StudentsSearch({
+  query,
+  onQueryChange,
+  results,
+  onSelect,
+  selectedId,
+  isLoading,
+  error,
+}) {
+  const listRef = useRef(null);
+
+  useEffect(() => {
+    if (!listRef.current) return;
+    const active = listRef.current.querySelector('[data-active="true"]');
+    if (active) {
+      active.scrollIntoView({ block: "nearest" });
+    }
+  }, [selectedId, results]);
+
+  return (
+    <section aria-label="Recherche étudiants" className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+      <div className="flex items-center justify-between gap-2">
+        <label className="flex-grow" htmlFor="students-search">
+          <span className="sr-only">Rechercher un étudiant</span>
+          <input
+            id="students-search"
+            type="search"
+            value={query}
+            placeholder="Rechercher par nom ou identifiant..."
+            onChange={(event) => onQueryChange(event.target.value)}
+            className="w-full rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm focus:border-indigo-500 focus:bg-white focus:outline-none focus:ring-2 focus:ring-indigo-200"
+          />
+        </label>
+      </div>
+
+      <div className="mt-3 text-xs text-slate-500">
+        {isLoading && "Chargement..."}
+        {error && <span className="text-rose-500">{error}</span>}
+        {!isLoading && !error && results.length === 0 && <span>Aucun étudiant trouvé.</span>}
+      </div>
+
+      <ul
+        ref={listRef}
+        className="mt-3 max-h-64 overflow-y-auto rounded-xl border border-slate-100"
+        role="listbox"
+        aria-label="Résultats"
+      >
+        {results.map((student) => {
+          const isActive = selectedId === student.id;
+          return (
+            <li
+              key={student.id}
+              role="option"
+              aria-selected={isActive}
+              data-active={isActive}
+              tabIndex={0}
+              className={`cursor-pointer px-4 py-3 text-sm transition focus:outline-none focus:ring-2 focus:ring-indigo-500 ${
+                isActive ? "bg-indigo-50 text-indigo-700" : "hover:bg-slate-50"
+              }`}
+              onClick={() => onSelect(student)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" || event.key === " ") {
+                  event.preventDefault();
+                  onSelect(student);
+                }
+              }}
+            >
+              <p className="font-semibold">{student.name}</p>
+              <p className="text-xs text-slate-500">{student.id}</p>
+              <p className="text-xs text-slate-500">
+                Dernière activité : {student.lastActivity ? formatDate(student.lastActivity) : "—"}
+              </p>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}
+
+StudentsSearch.propTypes = {
+  query: PropTypes.string.isRequired,
+  onQueryChange: PropTypes.func.isRequired,
+  results: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired,
+      lastActivity: PropTypes.string,
+    })
+  ).isRequired,
+  onSelect: PropTypes.func.isRequired,
+  selectedId: PropTypes.string,
+  isLoading: PropTypes.bool,
+  error: PropTypes.string,
+};
+

--- a/frontend/src/components/results/TimeDistributionChart.jsx
+++ b/frontend/src/components/results/TimeDistributionChart.jsx
@@ -1,0 +1,67 @@
+import PropTypes from "prop-types";
+import { formatDuration } from "../../lib/results/utils";
+
+export default function TimeDistributionChart({ data }) {
+  const total = data.reduce((sum, item) => sum + (item.totalTimeSec || 0), 0);
+  let currentAngle = 0;
+  const segments = data.map((item) => {
+    const ratio = total === 0 ? 0 : (item.totalTimeSec || 0) / total;
+    const startAngle = currentAngle;
+    const degrees = ratio * 360;
+    currentAngle += degrees;
+    return {
+      ...item,
+      ratio,
+      startAngle,
+      degrees,
+    };
+  });
+
+  const gradient = segments
+    .map((segment, index) => {
+      const start = segment.startAngle;
+      const end = segment.startAngle + segment.degrees;
+      const color = colors[index % colors.length];
+      return `${color} ${start}deg ${end}deg`;
+    })
+    .join(", ");
+
+  return (
+    <div className="flex flex-col items-center gap-4 lg:flex-row">
+      <div
+        className="relative h-56 w-56 rounded-full"
+        style={{ background: `conic-gradient(${gradient || "#e2e8f0 0deg 360deg"})` }}
+        aria-hidden
+      >
+        <div className="absolute inset-[20%] rounded-full bg-white shadow-inner" />
+      </div>
+      <ul className="flex-1 space-y-2 text-sm text-slate-600">
+        {segments.map((segment, index) => (
+          <li
+            key={segment.studentId}
+            className="flex items-center justify-between rounded-xl bg-slate-50 px-3 py-2"
+            style={{ borderLeft: `4px solid ${colors[index % colors.length]}` }}
+          >
+            <span className="font-medium text-slate-700">{segment.name}</span>
+            <span>
+              {formatDuration(segment.totalTimeSec)} · {(segment.ratio * 100 || 0).toFixed(1)}%
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+const colors = ["#6366f1", "#22d3ee", "#f97316", "#f43f5e", "#10b981", "#8b5cf6", "#0ea5e9", "#fb7185"];
+
+TimeDistributionChart.propTypes = {
+  data: PropTypes.arrayOf(
+    PropTypes.shape({
+      studentId: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired,
+      totalTimeSec: PropTypes.number.isRequired,
+    })
+  ).isRequired,
+};
+

--- a/frontend/src/components/results/TimeRangePicker.jsx
+++ b/frontend/src/components/results/TimeRangePicker.jsx
@@ -1,0 +1,89 @@
+import { useEffect, useMemo, useState } from "react";
+import PropTypes from "prop-types";
+
+const PRESETS = [
+  { label: "7 jours", value: "7d" },
+  { label: "30 jours", value: "30d" },
+  { label: "90 jours", value: "90d" },
+  { label: "Personnalisé", value: "custom" },
+];
+
+export default function TimeRangePicker({ value, onChange }) {
+  const [preset, setPreset] = useState(value?.preset || "30d");
+  const [customFrom, setCustomFrom] = useState(value?.from || "");
+  const [customTo, setCustomTo] = useState(value?.to || "");
+
+  useEffect(() => {
+    if (preset !== "custom") {
+      onChange?.({ preset });
+    } else if (customFrom && customTo) {
+      onChange?.({ preset, from: customFrom, to: customTo });
+    }
+  }, [preset, customFrom, customTo, onChange]);
+
+  useEffect(() => {
+    if (!value) return;
+    setPreset(value.preset || "30d");
+    setCustomFrom(value.from || "");
+    setCustomTo(value.to || "");
+  }, [value]);
+
+  const renderCustomInputs = useMemo(() => {
+    if (preset !== "custom") return null;
+    return (
+      <div className="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-2">
+        <label className="flex flex-col text-xs font-medium text-slate-600">
+          Du
+          <input
+            type="date"
+            value={customFrom}
+            onChange={(event) => setCustomFrom(event.target.value)}
+            className="mt-1 rounded-lg border border-slate-300 px-2 py-1 text-sm focus:border-indigo-500 focus:outline-none focus:ring"
+          />
+        </label>
+        <label className="flex flex-col text-xs font-medium text-slate-600">
+          Au
+          <input
+            type="date"
+            value={customTo}
+            onChange={(event) => setCustomTo(event.target.value)}
+            className="mt-1 rounded-lg border border-slate-300 px-2 py-1 text-sm focus:border-indigo-500 focus:outline-none focus:ring"
+          />
+        </label>
+      </div>
+    );
+  }, [preset, customFrom, customTo]);
+
+  return (
+    <fieldset className="rounded-xl border border-slate-200 bg-white p-3">
+      <legend className="mb-2 text-sm font-semibold text-slate-700">Période</legend>
+      <div className="flex flex-wrap gap-2">
+        {PRESETS.map((option) => (
+          <button
+            key={option.value}
+            type="button"
+            onClick={() => setPreset(option.value)}
+            className={`rounded-full border px-3 py-1 text-sm font-medium transition focus:outline-none focus:ring-2 focus:ring-indigo-500 ${
+              preset === option.value
+                ? "border-indigo-500 bg-indigo-500 text-white"
+                : "border-slate-200 bg-slate-50 text-slate-600 hover:border-indigo-300 hover:text-indigo-600"
+            }`}
+          >
+            {option.label}
+          </button>
+        ))}
+      </div>
+      {renderCustomInputs}
+    </fieldset>
+  );
+}
+
+TimeRangePicker.propTypes = {
+  value: PropTypes.shape({
+    preset: PropTypes.string,
+    from: PropTypes.string,
+    to: PropTypes.string,
+  }),
+  onChange: PropTypes.func,
+};
+

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -1,3 +1,4 @@
 // Base URL of the backend API
-// Uses Vite environment variable if provided, otherwise defaults to local server
-export const API_URL =  import.meta.env.VITE_API_URL || "https://allfront-production.up.railway.app";
+// Uses Vite environment variable if provided, otherwise defaults to production
+export const API_URL = import.meta.env.VITE_API_URL || "https://allfront-production.up.railway.app";
+

--- a/frontend/src/lib/results/api.js
+++ b/frontend/src/lib/results/api.js
@@ -1,0 +1,64 @@
+import { API_URL } from "../../config";
+
+const jsonHeaders = {
+  "Content-Type": "application/json",
+};
+
+const handleResponse = async (response) => {
+  if (!response.ok) {
+    const payload = await response.json().catch(() => ({}));
+    const message = payload.message || "Une erreur est survenue";
+    throw new Error(message);
+  }
+  return response.json();
+};
+
+export async function fetchSummary(token, { from, to } = {}) {
+  const params = new URLSearchParams();
+  if (from) params.append("from", from);
+  if (to) params.append("to", to);
+  const url = `${API_URL}/api/metrics/summary${params.toString() ? `?${params.toString()}` : ""}`;
+  const response = await fetch(url, {
+    headers: {
+      ...jsonHeaders,
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  return handleResponse(response);
+}
+
+export async function searchStudents(token, query) {
+  const params = new URLSearchParams();
+  if (query) params.append("query", query);
+  const url = `${API_URL}/api/students${params.toString() ? `?${params.toString()}` : ""}`;
+  const response = await fetch(url, {
+    headers: {
+      ...jsonHeaders,
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  return handleResponse(response);
+}
+
+export async function fetchStudentSeries(token, id) {
+  const response = await fetch(`${API_URL}/api/students/${id}/series`, {
+    headers: {
+      ...jsonHeaders,
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  return handleResponse(response);
+}
+
+export async function deleteData(token, payload) {
+  const response = await fetch(`${API_URL}/api/data`, {
+    method: "DELETE",
+    headers: {
+      ...jsonHeaders,
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(payload),
+  });
+  return handleResponse(response);
+}
+

--- a/frontend/src/lib/results/utils.js
+++ b/frontend/src/lib/results/utils.js
@@ -1,0 +1,166 @@
+/**
+ * Utilities for the Results workspace. Pure functions live here so they can be
+ * unit tested and reused across pages.
+ */
+
+/**
+ * Computes the delta Brest score for a chronologically sorted series. If the
+ * API already provides a delta value it is preserved; otherwise it is derived
+ * from the previous session score. The first session in the series has a delta
+ * of null.
+ *
+ * @param {Array<{ timestamp: string; BrestScore: number; deltaBrestScore?: number }>} series
+ * @returns {Array}
+ */
+export function computeDelta(series) {
+  if (!Array.isArray(series)) {
+    return [];
+  }
+
+  let previousScore = null;
+  return series
+    .slice()
+    .sort((a, b) => new Date(a.timestamp) - new Date(b.timestamp))
+    .map((session, index) => {
+      const explicitDelta =
+        typeof session.deltaBrestScore === "number" && Number.isFinite(session.deltaBrestScore)
+          ? session.deltaBrestScore
+          : null;
+
+      const computedDelta =
+        explicitDelta !== null
+          ? explicitDelta
+          : previousScore === null
+          ? null
+          : Number(session.BrestScore) - previousScore;
+
+      previousScore = Number(session.BrestScore);
+      return {
+        ...session,
+        deltaBrestScore: computedDelta,
+        index,
+      };
+    });
+}
+
+/**
+ * Formats a duration expressed in seconds to "Hh Mm". Seconds are rounded to
+ * the nearest minute to keep the UI readable.
+ *
+ * @param {number} seconds
+ * @returns {string}
+ */
+export function formatDuration(seconds) {
+  if (!Number.isFinite(seconds) || seconds < 0) {
+    return "0m";
+  }
+
+  const rounded = Math.round(seconds / 60);
+  const hours = Math.floor(rounded / 60);
+  const minutes = rounded % 60;
+
+  if (hours <= 0) {
+    return `${minutes}m`;
+  }
+
+  return minutes === 0 ? `${hours}h` : `${hours}h ${minutes}m`;
+}
+
+/**
+ * Formats an ISO timestamp to a human readable date.
+ * @param {string} iso
+ * @returns {string}
+ */
+export function formatDate(iso) {
+  if (!iso) return "";
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "";
+  return new Intl.DateTimeFormat("fr-FR", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  }).format(date);
+}
+
+/**
+ * Formats an ISO timestamp to a readable datetime.
+ * @param {string} iso
+ * @returns {string}
+ */
+export function formatDateTime(iso) {
+  if (!iso) return "";
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "";
+  return new Intl.DateTimeFormat("fr-FR", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(date);
+}
+
+/**
+ * Formats a Brest score with one decimal place.
+ * @param {number} value
+ * @returns {string}
+ */
+export function formatScore(value) {
+  if (!Number.isFinite(value)) {
+    return "0";
+  }
+  return Number(value).toFixed(1);
+}
+
+/**
+ * Exports an array of objects to CSV and triggers a download.
+ * @param {Array<Record<string, any>>} rows
+ * @param {string} filename
+ */
+export function exportToCsv(rows, filename = "sessions.csv") {
+  if (!Array.isArray(rows) || rows.length === 0) {
+    return;
+  }
+
+  const headers = Object.keys(rows[0]);
+  const csvRows = [headers.join(",")];
+
+  rows.forEach((row) => {
+    const values = headers.map((key) => {
+      const raw = row[key] ?? "";
+      const value = typeof raw === "string" ? raw : JSON.stringify(raw);
+      return `"${value.replace(/"/g, '""')}"`;
+    });
+    csvRows.push(values.join(","));
+  });
+
+  const blob = new Blob([csvRows.join("\n")], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.setAttribute("download", filename);
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+/**
+ * Computes a rolling sum by student for the time spent chart and splits the
+ * array into top entries plus an optional "Autres" bucket.
+ *
+ * @param {Array<{ studentId: string; name: string; totalTimeSec: number }>} data
+ * @param {number} maxEntries
+ */
+export function buildTimeDistribution(data, maxEntries = 6) {
+  if (!Array.isArray(data)) return [];
+  const sorted = data.slice().sort((a, b) => b.totalTimeSec - a.totalTimeSec);
+  const top = sorted.slice(0, maxEntries);
+  const rest = sorted.slice(maxEntries);
+  const othersTotal = rest.reduce((sum, item) => sum + (item.totalTimeSec || 0), 0);
+  if (othersTotal > 0) {
+    top.push({ studentId: "others", name: "Autres", totalTimeSec: othersTotal });
+  }
+  return top;
+}
+

--- a/frontend/src/lib/results/utils.test.js
+++ b/frontend/src/lib/results/utils.test.js
@@ -1,0 +1,47 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { computeDelta, formatDuration } from "./utils.js";
+
+describe("computeDelta", () => {
+  it("computes deltas for ordered sessions", () => {
+    const series = [
+      { id: "1", timestamp: "2024-01-01T10:00:00Z", BrestScore: 60 },
+      { id: "2", timestamp: "2024-01-02T10:00:00Z", BrestScore: 65 },
+      { id: "3", timestamp: "2024-01-03T10:00:00Z", BrestScore: 63 },
+    ];
+
+    const result = computeDelta(series);
+    assert.deepStrictEqual(result.map((item) => item.deltaBrestScore), [null, 5, -2]);
+  });
+
+  it("preserves provided delta values", () => {
+    const series = [
+      { id: "1", timestamp: "2024-01-01T10:00:00Z", BrestScore: 60, deltaBrestScore: null },
+      { id: "2", timestamp: "2024-01-02T10:00:00Z", BrestScore: 65, deltaBrestScore: 4 },
+    ];
+
+    const result = computeDelta(series);
+    assert.strictEqual(result[1].deltaBrestScore, 4);
+  });
+
+  it("returns empty array when input is invalid", () => {
+    assert.deepStrictEqual(computeDelta(null), []);
+    assert.deepStrictEqual(computeDelta(undefined), []);
+  });
+});
+
+describe("formatDuration", () => {
+  it("formats seconds under an hour", () => {
+    assert.strictEqual(formatDuration(900), "15m");
+  });
+
+  it("formats hours and minutes", () => {
+    assert.strictEqual(formatDuration(3660), "1h 1m");
+  });
+
+  it("handles zero and invalid inputs", () => {
+    assert.strictEqual(formatDuration(-5), "0m");
+    assert.strictEqual(formatDuration(undefined), "0m");
+  });
+});
+

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -152,6 +152,25 @@ export default function Home() {
               >
                 ⚡ Admin Dashboard
               </Link>
+              <Link
+                className="btn ghost"
+                to="/results"
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  padding: "12px 16px",
+                  borderRadius: "10px",
+                  textDecoration: "none",
+                  fontWeight: 700,
+                  background: "transparent",
+                  color: "#2563eb",
+                  border: "2px solid rgba(37,99,235,0.25)",
+                  marginTop: "8px",
+                }}
+              >
+                📊 Résultats
+              </Link>
             </>
           )}
         </div>

--- a/frontend/src/pages/results/AdminPage.jsx
+++ b/frontend/src/pages/results/AdminPage.jsx
@@ -1,0 +1,246 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { ShieldAlert } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "../../context/AuthContext";
+import { deleteData, searchStudents } from "../../lib/results/api";
+import { formatDateTime, formatDuration, formatScore } from "../../lib/results/utils";
+import DeleteForm from "../../components/results/DeleteForm";
+import DataTable from "../../components/results/DataTable";
+import ConfirmDialog from "../../components/results/ConfirmDialog";
+
+const initialDateRange = { from: "", to: "" };
+
+export default function AdminPage() {
+  const { token } = useAuth();
+  const navigate = useNavigate();
+  const [scope, setScope] = useState("all");
+  const [studentQuery, setStudentQuery] = useState("");
+  const [studentOptions, setStudentOptions] = useState([]);
+  const [studentsLoading, setStudentsLoading] = useState(false);
+  const [studentsError, setStudentsError] = useState(null);
+  const [selectedStudent, setSelectedStudent] = useState(null);
+  const [dateRange, setDateRange] = useState(initialDateRange);
+  const [preview, setPreview] = useState(null);
+  const [loadingPreview, setLoadingPreview] = useState(false);
+  const [previewError, setPreviewError] = useState(null);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [confirmationText, setConfirmationText] = useState("");
+  const [deleting, setDeleting] = useState(false);
+  const [successMessage, setSuccessMessage] = useState("");
+  const pendingDeletion = useMemo(() => {
+    if (!preview) return 0;
+    if (preview.deletedCount && preview.deletedCount > 0) {
+      return preview.deletedCount;
+    }
+    return preview.matchedCount || 0;
+  }, [preview]);
+
+  const columns = useMemo(
+    () => [
+      { key: "timestamp", label: "Date", render: (value) => formatDateTime(value) },
+      { key: "studentName", label: "Étudiant" },
+      { key: "BrestScore", label: "BRESTScore", render: (value) => formatScore(value) },
+      {
+        key: "deltaBrestScore",
+        label: "Δ",
+        render: (value) => (value === null || value === undefined ? "—" : `${value > 0 ? "+" : ""}${formatScore(value)}`),
+      },
+      { key: "timeSpentSec", label: "Durée", render: (value) => formatDuration(value) },
+    ],
+    []
+  );
+
+  const previewPayload = useMemo(() => {
+    const payload = { scope, dryRun: true };
+    if (scope === "student" && selectedStudent) payload.studentId = selectedStudent.id;
+    if (scope === "dateRange") {
+      if (dateRange.from) payload.from = dateRange.from;
+      if (dateRange.to) payload.to = dateRange.to;
+    }
+    return payload;
+  }, [scope, selectedStudent, dateRange]);
+
+  const canPreview = useMemo(() => {
+    if (scope === "student") return Boolean(selectedStudent);
+    if (scope === "dateRange") return Boolean(dateRange.from && dateRange.to);
+    return true;
+  }, [scope, selectedStudent, dateRange]);
+
+  const handlePreview = async () => {
+    if (!token || !canPreview) return;
+    try {
+      setLoadingPreview(true);
+      setPreviewError(null);
+      const result = await deleteData(token, previewPayload);
+      setPreview(result);
+      setConfirmationText("");
+      setSuccessMessage("");
+    } catch (error) {
+      setPreviewError(error.message);
+    } finally {
+      setLoadingPreview(false);
+    }
+  };
+
+  const fetchStudents = useCallback(
+    (value) => {
+      if (!token) return;
+      setStudentsLoading(true);
+      setStudentsError(null);
+      searchStudents(token, value)
+        .then((data) => setStudentOptions(data))
+        .catch((error) => setStudentsError(error.message))
+        .finally(() => setStudentsLoading(false));
+    },
+    [token]
+  );
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      if (scope === "student") {
+        fetchStudents(studentQuery);
+      }
+    }, 200);
+    return () => clearTimeout(handler);
+  }, [studentQuery, scope, fetchStudents]);
+
+  useEffect(() => {
+    if (scope !== "student") {
+      setSelectedStudent(null);
+    }
+    if (scope !== "dateRange") {
+      setDateRange(initialDateRange);
+    }
+    setPreview(null);
+    setSuccessMessage("");
+  }, [scope]);
+
+  const handleConfirmDelete = async () => {
+    if (!token || !preview) return;
+    setDeleting(true);
+    try {
+      const payload = { ...previewPayload, dryRun: false };
+      const result = await deleteData(token, payload);
+      setSuccessMessage(
+        `Suppression réussie : ${result.deletedCount} élément${result.deletedCount > 1 ? "s" : ""} supprimé${
+          result.deletedCount > 1 ? "s" : ""
+        }.`
+      );
+      setPreview(result);
+      setConfirmOpen(false);
+      setConfirmationText("");
+      setTimeout(() => navigate("/results"), 1500);
+    } catch (error) {
+      setPreviewError(error.message);
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-3xl border border-rose-200 bg-white p-6 shadow-sm">
+        <header className="mb-4 flex items-center gap-3 text-rose-600">
+          <ShieldAlert className="h-6 w-6" />
+          <div>
+            <h2 className="text-xl font-semibold">Suppression de données</h2>
+            <p className="text-xs text-rose-500">Les opérations sont irréversibles. Utiliser uniquement pour la maintenance.</p>
+          </div>
+        </header>
+        <DeleteForm
+          scope={scope}
+          onScopeChange={setScope}
+          studentQuery={studentQuery}
+          onStudentQueryChange={setStudentQuery}
+          students={studentOptions}
+          onSelectStudent={setSelectedStudent}
+          selectedStudent={selectedStudent}
+          dateRange={dateRange}
+          onDateRangeChange={setDateRange}
+          isLoadingStudents={studentsLoading}
+          studentError={studentsError}
+        />
+        <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <button
+            type="button"
+            onClick={handlePreview}
+            disabled={!canPreview || loadingPreview}
+            className="inline-flex items-center justify-center rounded-xl border border-rose-200 px-4 py-2 text-sm font-semibold text-rose-600 transition hover:border-rose-300 hover:text-rose-700 focus:outline-none focus:ring-2 focus:ring-rose-300 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            Prévisualiser
+          </button>
+          {preview && (
+            <p className="text-xs text-slate-500">Dernière prévisualisation : {new Date().toLocaleTimeString()}</p>
+          )}
+        </div>
+        {previewError && <p className="mt-4 rounded-lg bg-rose-50 p-3 text-sm text-rose-600">{previewError}</p>}
+        {successMessage && <p className="mt-4 rounded-lg bg-emerald-50 p-3 text-sm text-emerald-600">{successMessage}</p>}
+      </div>
+
+      {loadingPreview && <p className="text-sm text-slate-500">Chargement de la prévisualisation…</p>}
+
+      {preview && (
+        <section className="space-y-4">
+          <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+            <h3 className="text-lg font-semibold text-slate-900">Résultat de la prévisualisation</h3>
+            <p className="mt-2 text-sm text-slate-600">
+              {preview.matchedCount} élément{preview.matchedCount > 1 ? "s" : ""} trouvé{preview.matchedCount > 1 ? "s" : ""}.
+            </p>
+            {preview.warnings && preview.warnings.length > 0 && (
+              <ul className="mt-4 space-y-2 text-sm text-amber-600">
+                {preview.warnings.map((warning) => (
+                  <li key={warning} className="rounded-lg bg-amber-50 px-3 py-2">
+                    {warning}
+                  </li>
+                ))}
+              </ul>
+            )}
+            <div className="mt-4 flex justify-between text-sm text-slate-500">
+              <span>Éléments supprimés si confirmé : {pendingDeletion}</span>
+              <button
+                type="button"
+                onClick={() => setConfirmOpen(true)}
+                disabled={pendingDeletion === 0}
+                className="rounded-xl bg-rose-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-rose-700 focus:outline-none focus:ring-2 focus:ring-rose-400 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                Supprimer définitivement
+              </button>
+            </div>
+          </div>
+          <DataTable columns={columns} rows={preview.sample || []} emptyLabel="Aucun échantillon" />
+        </section>
+      )}
+
+      <ConfirmDialog
+        open={confirmOpen}
+        title="Confirmer la suppression"
+        description="Cette action supprimera définitivement les données sélectionnées. Tapez DELETE pour continuer."
+        confirmLabel={deleting ? "Suppression…" : "Confirmer"}
+        confirmDisabled={confirmationText !== "DELETE" || deleting}
+        onCancel={() => {
+          setConfirmOpen(false);
+          setConfirmationText("");
+        }}
+        onConfirm={handleConfirmDelete}
+      />
+
+      {confirmOpen && (
+        <div className="fixed inset-x-0 bottom-0 z-50 bg-white/90 px-6 py-4 shadow-lg">
+          <div className="mx-auto flex max-w-lg flex-col gap-3">
+            <label className="text-sm font-semibold text-slate-700" htmlFor="confirm-input">
+              Saisissez DELETE pour confirmer
+            </label>
+            <input
+              id="confirm-input"
+              type="text"
+              value={confirmationText}
+              onChange={(event) => setConfirmationText(event.target.value)}
+              className="rounded-lg border border-rose-300 px-3 py-2 text-sm focus:border-rose-400 focus:outline-none focus:ring-2 focus:ring-rose-300"
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/frontend/src/pages/results/DashboardPage.jsx
+++ b/frontend/src/pages/results/DashboardPage.jsx
@@ -1,0 +1,192 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { RefreshCcw } from "lucide-react";
+import { useAuth } from "../../context/AuthContext";
+import { fetchSummary } from "../../lib/results/api";
+import { buildTimeDistribution, formatDuration, formatScore } from "../../lib/results/utils";
+import KpiCard from "../../components/results/KpiCard";
+import TimeRangePicker from "../../components/results/TimeRangePicker";
+import SessionsAreaChart from "../../components/results/SessionsAreaChart";
+import HorizontalBarChart from "../../components/results/HorizontalBarChart";
+import TimeDistributionChart from "../../components/results/TimeDistributionChart";
+
+const nowIso = () => new Date().toISOString().slice(0, 10);
+
+const resolvePresetRange = (preset) => {
+  const end = new Date();
+  const start = new Date();
+  if (preset === "7d") start.setDate(end.getDate() - 7);
+  else if (preset === "30d") start.setDate(end.getDate() - 30);
+  else if (preset === "90d") start.setDate(end.getDate() - 90);
+  return { from: start.toISOString().slice(0, 10), to: nowIso() };
+};
+
+export default function DashboardPage() {
+  const { token } = useAuth();
+  const [range, setRange] = useState({ preset: "30d", ...resolvePresetRange("30d") });
+  const [summary, setSummary] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [chartWindow, setChartWindow] = useState(30);
+  const fetchData = useCallback(async () => {
+    if (!token) return;
+    try {
+      setLoading(true);
+      setError(null);
+      const params = range.preset === "custom" ? range : resolvePresetRange(range.preset);
+      const data = await fetchSummary(token, params);
+      setSummary(data);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }, [token, range]);
+
+  const handleRefresh = () => {
+    fetchData();
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  const kpis = useMemo(() => {
+    if (!summary) return [];
+    const deltaValue = Number(summary.avgDeltaBrestScore ?? 0);
+    const formattedDelta = `${deltaValue > 0 ? "+" : ""}${formatScore(deltaValue)}`;
+    return [
+      {
+        title: "Étudiants",
+        value: summary.totalStudents ?? 0,
+        accent: "default",
+        icon: "🎓",
+      },
+      {
+        title: "Sessions",
+        value: summary.totalSessions ?? 0,
+        accent: "default",
+        icon: "🗂️",
+      },
+      {
+        title: "BRESTScore moyen",
+        value: formatScore(summary.avgBrestScore ?? 0),
+        accent: "success",
+        icon: "📈",
+      },
+      {
+        title: "Δ moyen",
+        value: formattedDelta,
+        accent: deltaValue >= 0 ? "success" : "danger",
+        icon: deltaValue >= 0 ? "⬆️" : "⬇️",
+      },
+      {
+        title: "Temps total",
+        value: formatDuration((summary.totalTimeHours ?? 0) * 3600),
+        accent: "warning",
+        icon: "⏱️",
+      },
+    ];
+  }, [summary]);
+
+  const busiestDays = useMemo(() => {
+    if (!summary) return [];
+    const limitDate = new Date();
+    limitDate.setDate(limitDate.getDate() - chartWindow);
+    return summary.busiestDays
+      .filter((day) => new Date(day.date) >= limitDate)
+      .map((day) => ({ ...day, label: day.date.slice(5) }));
+  }, [summary, chartWindow]);
+
+  const topImprovers = useMemo(() => {
+    if (!summary) return [];
+    return summary.topImprovers.slice(0, 10).map((student) => ({
+      ...student,
+      avgDelta: Number(student.avgDelta || 0),
+      displayDelta: Number(student.avgDelta || 0).toFixed(2),
+    }));
+  }, [summary]);
+
+  const timeDistribution = useMemo(() => {
+    if (!summary) return [];
+    return buildTimeDistribution(summary.timeDistribution || []);
+  }, [summary]);
+
+  return (
+    <div className="space-y-8">
+      <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <TimeRangePicker value={range} onChange={setRange} />
+          <button
+            type="button"
+            onClick={handleRefresh}
+            className="inline-flex items-center gap-2 rounded-xl border border-indigo-200 px-4 py-2 text-sm font-semibold text-indigo-600 transition hover:border-indigo-400 hover:text-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-400"
+          >
+            <RefreshCcw className="h-4 w-4" /> Rafraîchir
+          </button>
+        </div>
+        {error && <p className="mt-4 rounded-lg bg-rose-50 p-3 text-sm text-rose-600">{error}</p>}
+        {loading && <p className="mt-4 text-sm text-slate-500">Chargement des indicateurs…</p>}
+        {!loading && summary && (
+          <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
+            {kpis.map((kpi) => (
+              <KpiCard key={kpi.title} {...kpi} />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {!loading && summary && (
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+          <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+            <header className="mb-4 flex items-center justify-between">
+              <div>
+                <h2 className="text-lg font-semibold text-slate-900">Sessions quotidiennes</h2>
+                <p className="text-xs text-slate-500">Nombre de sessions terminées par jour</p>
+              </div>
+              <div className="flex gap-2">
+                {[30, 90].map((value) => (
+                  <button
+                    key={value}
+                    type="button"
+                    onClick={() => setChartWindow(value)}
+                    className={`rounded-full px-3 py-1 text-xs font-semibold transition focus:outline-none focus:ring-2 focus:ring-indigo-400 ${
+                      chartWindow === value
+                        ? "bg-indigo-500 text-white"
+                        : "border border-indigo-200 text-indigo-600 hover:border-indigo-400"
+                    }`}
+                  >
+                    {value} jours
+                  </button>
+                ))}
+              </div>
+            </header>
+            <div className="h-72">
+              <SessionsAreaChart data={busiestDays.map((item) => ({ ...item, value: item.sessions }))} />
+            </div>
+          </section>
+
+          <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+            <header className="mb-4">
+              <h2 className="text-lg font-semibold text-slate-900">Top améliorations</h2>
+              <p className="text-xs text-slate-500">Moyenne des variations du BRESTScore</p>
+            </header>
+            <HorizontalBarChart
+              data={topImprovers.map((item) => ({ ...item, label: item.name, value: item.avgDelta }))}
+              valueKey="value"
+              labelKey="label"
+            />
+          </section>
+
+          <section className="lg:col-span-2 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+            <header className="mb-4">
+              <h2 className="text-lg font-semibold text-slate-900">Répartition du temps passé</h2>
+              <p className="text-xs text-slate-500">Temps cumulé par étudiant</p>
+            </header>
+            <TimeDistributionChart data={timeDistribution} />
+          </section>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/frontend/src/pages/results/ResultsLayout.jsx
+++ b/frontend/src/pages/results/ResultsLayout.jsx
@@ -1,0 +1,51 @@
+import { NavLink, Outlet } from "react-router-dom";
+
+const tabs = [
+  { to: "/results", label: "Tableau de bord", exact: true },
+  { to: "/results/students", label: "Étudiants" },
+  { to: "/results/admin", label: "Administration" },
+];
+
+export default function ResultsLayout() {
+  return (
+    <div className="min-h-screen bg-slate-100 py-8">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4">
+        <header className="flex flex-col gap-4 rounded-3xl bg-white p-6 shadow-sm">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-widest text-indigo-500">Résultats</p>
+            <h1 className="text-3xl font-bold text-slate-900">Espace de pilotage</h1>
+            <p className="mt-2 max-w-3xl text-sm text-slate-600">
+              Suivez les indicateurs clés, analysez les progrès des étudiants et gérez les données
+              collectées par la plateforme.
+            </p>
+          </div>
+          <nav aria-label="Navigation des résultats">
+            <ul className="flex flex-wrap gap-3">
+              {tabs.map((tab) => (
+                <li key={tab.to}>
+                  <NavLink
+                    to={tab.to}
+                    end={tab.exact}
+                    className={({ isActive }) =>
+                      `inline-flex items-center rounded-full border px-4 py-2 text-sm font-semibold transition focus:outline-none focus:ring-2 focus:ring-indigo-500 ${
+                        isActive
+                          ? "border-indigo-500 bg-indigo-500 text-white"
+                          : "border-slate-200 bg-slate-50 text-slate-600 hover:border-indigo-300 hover:text-indigo-600"
+                      }`
+                    }
+                  >
+                    {tab.label}
+                  </NavLink>
+                </li>
+              ))}
+            </ul>
+          </nav>
+        </header>
+        <main className="pb-12">
+          <Outlet />
+        </main>
+      </div>
+    </div>
+  );
+}
+

--- a/frontend/src/pages/results/StudentsPage.jsx
+++ b/frontend/src/pages/results/StudentsPage.jsx
@@ -1,0 +1,183 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { AlertTriangle } from "lucide-react";
+import { useAuth } from "../../context/AuthContext";
+import { fetchStudentSeries, searchStudents } from "../../lib/results/api";
+import { computeDelta, exportToCsv, formatDateTime, formatDuration, formatScore } from "../../lib/results/utils";
+import StudentsSearch from "../../components/results/StudentsSearch";
+import StudentCharts from "../../components/results/StudentCharts";
+import DataTable from "../../components/results/DataTable";
+
+export default function StudentsPage() {
+  const { token } = useAuth();
+  const [query, setQuery] = useState("");
+  const [studentResults, setStudentResults] = useState([]);
+  const [studentsLoading, setStudentsLoading] = useState(false);
+  const [studentsError, setStudentsError] = useState(null);
+  const [selectedStudent, setSelectedStudent] = useState(null);
+  const [series, setSeries] = useState([]);
+  const [seriesLoading, setSeriesLoading] = useState(false);
+  const [seriesError, setSeriesError] = useState(null);
+
+  const debouncedSearch = useCallback(
+    (value) => {
+      if (!token) return;
+      setStudentsLoading(true);
+      setStudentsError(null);
+      searchStudents(token, value)
+        .then((data) => setStudentResults(data))
+        .catch((error) => setStudentsError(error.message))
+        .finally(() => setStudentsLoading(false));
+    },
+    [token]
+  );
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      debouncedSearch(query);
+    }, 250);
+    return () => clearTimeout(handler);
+  }, [query, debouncedSearch]);
+
+  useEffect(() => {
+    if (studentResults.length > 0 && !selectedStudent) {
+      setSelectedStudent(studentResults[0]);
+    }
+  }, [studentResults, selectedStudent]);
+
+  useEffect(() => {
+    if (!token || !selectedStudent) return;
+    setSeriesLoading(true);
+    setSeriesError(null);
+    fetchStudentSeries(token, selectedStudent.id)
+      .then((data) => {
+        const computed = computeDelta(data.series);
+        setSeries(computed);
+      })
+      .catch((error) => setSeriesError(error.message))
+      .finally(() => setSeriesLoading(false));
+  }, [token, selectedStudent]);
+
+  const stats = useMemo(() => {
+    if (!series || series.length === 0) return null;
+    const totalSessions = series.length;
+    const avgScore =
+      series.reduce((sum, session) => sum + Number(session.BrestScore || 0), 0) / totalSessions;
+    const totalTime = series.reduce((sum, session) => sum + Number(session.timeSpentSec || 0), 0);
+    return {
+      totalSessions,
+      avgScore: formatScore(avgScore),
+      totalTime: formatDuration(totalTime),
+    };
+  }, [series]);
+
+  const columns = useMemo(
+    () => [
+      { key: "timestamp", label: "Date", render: (value) => formatDateTime(value) },
+      { key: "BrestScore", label: "BRESTScore", render: (value) => formatScore(value) },
+      {
+        key: "deltaBrestScore",
+        label: "Δ",
+        render: (value) => (value === null || value === undefined ? "—" : `${value > 0 ? "+" : ""}${formatScore(value)}`),
+      },
+      {
+        key: "timeSpentSec",
+        label: "Durée",
+        render: (value) => formatDuration(value),
+      },
+    ],
+    []
+  );
+
+  const exportRows = useMemo(
+    () =>
+      series.map((session) => ({
+        id: session.id,
+        timestamp: formatDateTime(session.timestamp),
+        BrestScore: formatScore(session.BrestScore),
+        deltaBrestScore:
+          session.deltaBrestScore === null || session.deltaBrestScore === undefined
+            ? ""
+            : `${session.deltaBrestScore > 0 ? "+" : ""}${formatScore(session.deltaBrestScore)}`,
+        timeSpent: formatDuration(session.timeSpentSec),
+      })),
+    [series]
+  );
+
+  return (
+    <div className="grid grid-cols-1 gap-6 lg:grid-cols-[320px_1fr]">
+      <StudentsSearch
+        query={query}
+        onQueryChange={setQuery}
+        results={studentResults}
+        onSelect={setSelectedStudent}
+        selectedId={selectedStudent?.id || null}
+        isLoading={studentsLoading}
+        error={studentsError}
+      />
+
+      <section className="space-y-6">
+        {!selectedStudent && (
+          <div className="flex items-center gap-3 rounded-2xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-700">
+            <AlertTriangle className="h-5 w-5" />
+            <p>Sélectionnez un étudiant pour consulter les détails.</p>
+          </div>
+        )}
+
+        {selectedStudent && (
+          <div className="space-y-6">
+            <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+              <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <h2 className="text-2xl font-semibold text-slate-900">{selectedStudent.name}</h2>
+                  <p className="text-xs text-slate-500">ID : {selectedStudent.id}</p>
+                </div>
+                {stats && (
+                  <dl className="grid grid-cols-2 gap-4 text-sm text-slate-600 sm:grid-cols-3">
+                    <div>
+                      <dt className="font-semibold text-slate-700">Sessions</dt>
+                      <dd>{stats.totalSessions}</dd>
+                    </div>
+                    <div>
+                      <dt className="font-semibold text-slate-700">Score moyen</dt>
+                      <dd>{stats.avgScore}</dd>
+                    </div>
+                    <div>
+                      <dt className="font-semibold text-slate-700">Temps cumulé</dt>
+                      <dd>{stats.totalTime}</dd>
+                    </div>
+                  </dl>
+                )}
+              </header>
+              {seriesLoading && <p className="mt-4 text-sm text-slate-500">Chargement des sessions…</p>}
+              {seriesError && <p className="mt-4 rounded-lg bg-rose-50 p-3 text-sm text-rose-600">{seriesError}</p>}
+              {!seriesLoading && !seriesError && series.length === 0 && (
+                <p className="mt-6 text-sm text-slate-500">Aucune session enregistrée pour cet étudiant.</p>
+              )}
+            </div>
+
+            {!seriesLoading && !seriesError && series.length > 0 && (
+              <>
+                <StudentCharts series={series} />
+
+                <div className="space-y-4">
+                  <div className="flex items-center justify-between">
+                    <h3 className="text-lg font-semibold text-slate-800">Historique des sessions</h3>
+                    <button
+                      type="button"
+                      onClick={() => exportToCsv(exportRows)}
+                      className="rounded-xl border border-indigo-200 px-4 py-2 text-sm font-semibold text-indigo-600 transition hover:border-indigo-400 hover:text-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-400"
+                    >
+                      Export CSV
+                    </button>
+                  </div>
+                  <DataTable columns={columns} rows={series} />
+                </div>
+              </>
+            )}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add a PostgreSQL-backed results service that computes summary metrics, student search results, and per-student series using live session data
- update the results routes to honor the RESULTS_USE_DB flag and fall back to mocks while blocking destructive deletes in database mode

## Testing
- npm run build
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d2b56ccc888329a93ed638eb75a68f