### PR TITLE
Add reusable user menu header across protected pages

### DIFF
--- a/frontend/src/components/TopRightUserMenu.jsx
+++ b/frontend/src/components/TopRightUserMenu.jsx
@@ -1,0 +1,32 @@
+import { Link, useLocation } from "react-router-dom";
+import { useAuth } from "../context/AuthContext";
+
+export default function TopRightUserMenu({ className = "", style }) {
+  const { user, logout } = useAuth();
+  const location = useLocation();
+
+  const handleLogout = () => {
+    if (window.confirm("Êtes-vous sûr de vouloir vous déconnecter ?")) {
+      logout();
+    }
+  };
+
+  const isHome = location.pathname === "/";
+
+  return (
+    <div className={`top-right-user-menu ${className}`.trim()} style={style}>
+      <Link
+        to="/"
+        className={`top-right-user-menu__link ${isHome ? "top-right-user-menu__link--active" : ""}`.trim()}
+      >
+        Accueil
+      </Link>
+      <span className="top-right-user-menu__greeting">
+        Bonjour, {user?.name || "Utilisateur"}
+      </span>
+      <button type="button" className="top-right-user-menu__logout" onClick={handleLogout}>
+        Déconnexion
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/UI.jsx
+++ b/frontend/src/components/UI.jsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect } from "react";
 import { useChat } from "../hooks/useChat";
 import { useAuth } from "../context/AuthContext";
+import TopRightUserMenu from "./TopRightUserMenu";
 
 export const UI = ({ hidden, ...props }) => {
     const { user, logout, token } = useAuth();
@@ -96,6 +97,10 @@ export const UI = ({ hidden, ...props }) => {
             <div className="self-start backdrop-blur-md bg-white bg-opacity-50 p-4 rounded-lg flex items-center gap-2">
                 <img src="images/logo-chaptal.png" alt="Fondation Léonie Chaptal" className="h-10" />
                 <span className="text-lg font-semibold text-chaptal-purple">Fondation Léonie Chaptal</span>
+            </div>
+
+            <div className="self-end pointer-events-auto">
+                <TopRightUserMenu />
             </div>
 
             {/* Auxiliary buttons */}

--- a/frontend/src/pages/Chat.jsx
+++ b/frontend/src/pages/Chat.jsx
@@ -3,6 +3,7 @@ import "../style.css";
 import logo from "../assets/logo.png";
 import { useAuth } from "../context/AuthContext";
 import { API_URL } from "../config";
+import TopRightUserMenu from "../components/TopRightUserMenu";
 
 export default function Chat() {
     const [prompt, setPrompt] = useState("");
@@ -92,12 +93,6 @@ export default function Chat() {
         }
     };
 
-    const handleLogout = () => {
-        if (window.confirm("Êtes-vous sûr de vouloir vous déconnecter ?")) {
-            logout();
-        }
-    };
-
     return (
         <div className="main-container">
             {/* HEADER */}
@@ -107,27 +102,8 @@ export default function Chat() {
                     <span className="foundation-name">Fondation Léonie Chaptal</span>
                 </div>
                 <h1>Plateforme P-2 : Atelier de Feedback Réflexif</h1>
-                <nav className="nav-links">
-                    <a href="/" className="active">Accueil</a>
-                    <div className="user-info" style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
-                        <span style={{ color: '#666', fontSize: '0.9rem' }}>
-                            Bonjour, {user?.name || 'Utilisateur'}
-                        </span>
-                        <button
-                            onClick={handleLogout}
-                            style={{
-                                padding: '6px 12px',
-                                borderRadius: '6px',
-                                border: '1px solid #ddd',
-                                background: '#f8f9fa',
-                                color: '#666',
-                                cursor: 'pointer',
-                                fontSize: '0.85rem'
-                            }}
-                        >
-                            Déconnexion
-                        </button>
-                    </div>
+                <nav className="nav-links" aria-label="Navigation principale">
+                    <TopRightUserMenu />
                 </nav>
             </header>
 

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -3,6 +3,7 @@ import { useAuth } from "../context/AuthContext";
 import { Loader2 } from "lucide-react";
 import { API_URL } from "../config";
 import "../style.css";
+import TopRightUserMenu from "../components/TopRightUserMenu";
 
 export default function AdminDashboard() {
     const { user, token } = useAuth();
@@ -60,6 +61,9 @@ export default function AdminDashboard() {
 
     return (
         <div className="min-h-screen p-6" style={{ background: "var(--bg-light)" }}>
+            <div className="flex justify-end mb-6">
+                <TopRightUserMenu />
+            </div>
             <h1 className="text-3xl font-bold text-gray-800 mb-6">
                 Admin Dashboard
             </h1>

--- a/frontend/src/pages/results/ResultsLayout.jsx
+++ b/frontend/src/pages/results/ResultsLayout.jsx
@@ -1,4 +1,5 @@
 import { NavLink, Outlet } from "react-router-dom";
+import TopRightUserMenu from "../../components/TopRightUserMenu";
 
 const tabs = [
   { to: "/results", label: "Tableau de bord", exact: true },
@@ -11,13 +12,16 @@ export default function ResultsLayout() {
     <div className="min-h-screen bg-slate-100 py-8">
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4">
         <header className="flex flex-col gap-4 rounded-3xl bg-white p-6 shadow-sm">
-          <div>
-            <p className="text-xs font-semibold uppercase tracking-widest text-indigo-500">Résultats</p>
-            <h1 className="text-3xl font-bold text-slate-900">Espace de pilotage</h1>
-            <p className="mt-2 max-w-3xl text-sm text-slate-600">
-              Suivez les indicateurs clés, analysez les progrès des étudiants et gérez les données
-              collectées par la plateforme.
-            </p>
+          <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-widest text-indigo-500">Résultats</p>
+              <h1 className="text-3xl font-bold text-slate-900">Espace de pilotage</h1>
+              <p className="mt-2 max-w-3xl text-sm text-slate-600">
+                Suivez les indicateurs clés, analysez les progrès des étudiants et gérez les données
+                collectées par la plateforme.
+              </p>
+            </div>
+            <TopRightUserMenu className="shrink-0" />
           </div>
           <nav aria-label="Navigation des résultats">
             <ul className="flex flex-wrap gap-3">

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -75,6 +75,54 @@ header h1 {
     border-bottom: 2px solid var(--primary-color);
 }
 
+.top-right-user-menu {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.5rem 0.85rem;
+    background-color: #f8f9fa;
+    border: 1px solid var(--border-color);
+    border-radius: 999px;
+    box-shadow: 0 2px 4px rgba(15, 23, 42, 0.06);
+    font-size: 0.9rem;
+    color: var(--text-light);
+    transition: background-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.top-right-user-menu__link {
+    color: var(--primary-color);
+    font-weight: 600;
+    text-decoration: none;
+    padding-bottom: 0.1rem;
+}
+
+.top-right-user-menu__link:hover,
+.top-right-user-menu__link--active {
+    border-bottom: 2px solid var(--primary-color);
+}
+
+.top-right-user-menu__greeting {
+    color: #5f6368;
+    font-size: 0.85rem;
+}
+
+.top-right-user-menu__logout {
+    padding: 0.4rem 0.9rem;
+    border-radius: 0.6rem;
+    border: 1px solid #dcdfe6;
+    background: linear-gradient(180deg, #ffffff 0%, #f3f4f6 100%);
+    color: #4a4a4a;
+    cursor: pointer;
+    font-size: 0.85rem;
+    font-weight: 500;
+    transition: all 0.2s ease;
+}
+
+.top-right-user-menu__logout:hover {
+    background: #ffffff;
+    box-shadow: 0 2px 6px rgba(148, 163, 184, 0.25);
+}
+
 /* Scenario Banner */
 .scenario-banner {
     background-color: var(--primary-light);


### PR DESCRIPTION
## Summary
- create a reusable top-right user menu that mirrors the chat page controls
- integrate the shared header block into the chat, simulation UI, admin dashboard, and results layout
- add styling for the shared menu to ensure consistent presentation across pages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbec351c488329af3dd43d5b7f33a0